### PR TITLE
Add LiteDB vector store connector

### DIFF
--- a/docs/LiteDbConnectorProgress.md
+++ b/docs/LiteDbConnectorProgress.md
@@ -1,0 +1,10 @@
+# LiteDB Connector Progress
+
+- [x] Project setup with LiteDB dependency and solution wiring
+- [x] Core entity and model mapping helpers
+- [x] Collection implementation for CRUD, search, and metadata
+- [x] Vector store wrapper and collection management APIs
+- [x] Basic expression filtering and vector index integration
+- [x] Unit tests covering CRUD and similarity search
+- [x] Documentation for package usage and configuration
+- [ ] Advanced filter translation and embedding generation support

--- a/docs/LiteDbVectorStoreConnector.md
+++ b/docs/LiteDbVectorStoreConnector.md
@@ -1,0 +1,63 @@
+# LiteDB Vector Store Connector
+
+The LiteDB connector provides an embedded, single-file vector store that implements the `Microsoft.Extensions.VectorData` abstractions. Use it when you need a managed, cross-platform vector store without external dependencies.
+
+## Package
+
+Add a reference to the `Microsoft.SemanticKernel.Connectors.LiteDb` package. The connector depends on `LiteDB` `6.0.0-prerelease.63` to access the new vector index capabilities.
+
+```
+dotnet add package Microsoft.SemanticKernel.Connectors.LiteDb
+```
+
+## Getting started
+
+````csharp
+using Microsoft.SemanticKernel.Connectors.LiteDb;
+using Microsoft.Extensions.VectorData;
+
+var store = new LiteDbVectorStore(new LiteDbVectorStoreOptions
+{
+    ConnectionString = "Filename=./vectors.db;Connection=direct",
+});
+
+var collection = store.GetCollection<string, DocumentRecord>("documents");
+await collection.EnsureCollectionExistsAsync();
+
+await collection.UpsertAsync(new DocumentRecord
+{
+    Id = "alpha",
+    Title = "LiteDB introduction",
+    Vector = new float[] { 0.1f, 0.2f, 0.3f }
+});
+
+await foreach (var result in collection.SearchAsync(new float[] { 0.1f, 0.2f, 0.3f }, top: 1))
+{
+    Console.WriteLine($"Found {result.Record.Title} (score: {result.Score})");
+}
+
+public sealed class DocumentRecord
+{
+    [VectorStoreKey]
+    public string Id { get; set; } = string.Empty;
+
+    [VectorStoreData]
+    public string Title { get; set; } = string.Empty;
+
+    [VectorStoreVector(Dimensions = 3)]
+    public ReadOnlyMemory<float> Vector { get; set; }
+}
+````
+
+### Options
+
+* `ConnectionString` – LiteDB connection string. Required when a database factory is not supplied.
+* `CollectionNamePrefix` – optional prefix applied to all collection names created by the store.
+* `DefaultDistanceMetric` – default LiteDB distance metric when vector properties do not specify one.
+* `AutoCreateVectorIndexes` – automatically ensure vector indexes exist when creating collections.
+
+### Limitations
+
+* Only single string keys are supported in the current implementation.
+* Vector properties must use `ReadOnlyMemory<float>` or `float[]`.
+* Expression filters are evaluated client side until a translation layer is implemented.

--- a/docs/LiteDbVectorStoreConnectorPlan.md
+++ b/docs/LiteDbVectorStoreConnectorPlan.md
@@ -1,0 +1,75 @@
+# LiteDB Vector Store Connector Plan
+
+## Overview
+LiteDB v6.0.0-prerelease.0052 introduces a native `BsonVector` type, HNSW-based vector indexes, fluent query helpers, and SQL support for vector similarity. These capabilities enable Semantic Kernel to offer an embedded, single-file vector store with managed code only, addressing locking and space-reclamation issues called out in SqliteVec discussions. This document outlines the plan to deliver a first-class LiteDB-backed connector for the Semantic Kernel Vector Store abstractions.
+
+## Goals
+- Provide a production-ready `LiteDbVectorStore` and `LiteDbVectorStoreRecordCollection<TRecord>` implementation aligned with `IVectorStore` contracts.
+- Leverage LiteDB's vector indexes for cosine (default), dot-product, and Euclidean similarity search.
+- Support CRUD semantics with transactional guarantees so deleted vectors are reclaimed on disk automatically.
+- Keep the connector dependency-light (only `LiteDB` 6.0.0-prerelease.63) and friendly to desktop, mobile, and edge deployments.
+- Offer parity with existing connectors (SqliteVec, Azure Cosmos DB, etc.) including filtering, metadata storage, and asynchronous APIs.
+
+## Non-Goals
+- Implement embedding generation or orchestration; responsibility remains with kernel skills.
+- Replace existing connectors; LiteDB is an additional option focused on managed, embedded scenarios.
+- Depend on LiteDB preview features outside of vector search functionality.
+
+## Key Requirements
+1. **Package management**: Add `LiteDB` 6.0.0-prerelease.63 NuGet dependency to a new `Microsoft.SemanticKernel.Connectors.LiteDb` project targeting `netstandard2.1` and `net8.0` to match other connectors.
+2. **Data model alignment**: Map SK records to LiteDB collections using a BSON document containing:
+   - Primary key (`_id`) with developer-provided string ID.
+   - Embedding stored as `BsonVector` via `float[]` serialization.
+   - Optional metadata payload stored as `BsonDocument` (dictionary of primitives/arrays).
+   - Additional fields required by `VectorStoreRecordDefinition` (timestamp, tags, references).
+3. **Indexing**: Ensure collection creation calls `EnsureIndex` with `VectorIndexOptions` specifying embedding dimensionality and distance metric (default cosine). Provide configuration for alternative metrics.
+4. **Search API**: Implement `TopNK` searches through `ILiteQueryable<T>` `TopKNear` extension. Support optional filter predicates translated from SK filter expressions into LiteDB `Query` objects.
+5. **Filtering strategy**: Initially support equality, comparison, and logical operators on scalar metadata fields. Document limitations for complex nested filters and plan incremental expansion.
+6. **Transactions and concurrency**: Use LiteDB's default transaction-per-operation semantics with `BeginTrans` when batching writes. Document concurrency model (single-writer, multiple-reader) and guidance for async usage.
+7. **Serialization helpers**: Provide converters between SK `VectorStoreRecordData`/`VectorStoreRecordDefinition` and LiteDB types, ensuring deterministic field naming.
+8. **Configuration surface**: Expose options object for file path, connection string, collection name prefix, vector dimension, distance metric, and automatic index creation flag.
+9. **Testing**: Add unit tests covering CRUD, similarity search accuracy, filter application, and transactional deletes. Include integration tests running against in-memory (temporary file) LiteDB database.
+10. **Documentation & samples**: Author README section demonstrating setup, ingestion, query, and deletion workflows along with guidance on embedding dimension management.
+
+## Design Considerations
+- **Connector placement**: Mirror existing connector layout under `dotnet/src/Connectors/VectorStores`. Introduce solution/project wiring and assembly metadata consistent with other connectors.
+- **Dependency versioning**: Pin to `LiteDB` 6.0.0-prerelease.63; monitor release channel for API changes between prerelease builds.
+- **Vector dimension management**: Require caller to specify embedding size when creating a collection; store this in a metadata document to enforce consistency on subsequent operations.
+- **Distance metrics**: Provide options for `Cosine`, `DotProduct`, and `Euclidean`. Default to cosine per LiteDB release guidance and SK conventions. Validate metric compatibility during search operations.
+- **Filter translation**: Reuse existing filter AST utilities where possible; otherwise implement LiteDB-specific translator with clear error messages for unsupported operators.
+- **Async pattern**: LiteDB APIs are synchronous. Wrap operations in `Task.Run` only when necessary, but prefer synchronous methods exposed via `ValueTask` to avoid unnecessary thread pool usage. Document expectation for caller to run on background thread when high throughput is required.
+- **Resource lifecycle**: Offer factory methods accepting `LiteDatabase` instance or connection string. Manage disposal carefully to avoid double-closing shared databases.
+- **Schema evolution**: Include version marker in a dedicated metadata collection for future migrations.
+
+## Work Breakdown Structure
+1. **Project Setup**
+   - Create connector project, add package reference, update solution files, and configure analyzers.
+2. **Core Entities**
+   - Define record schema classes, configuration options, and internal helpers for BSON conversion.
+3. **Collection Implementation**
+   - Implement `LiteDbVectorStoreRecordCollection<TRecord>` covering CRUD, search, upsert, delete, and iterator APIs.
+4. **Store Wrapper**
+   - Implement `LiteDbVectorStore` to create and manage collections with dimension validation and caching.
+5. **Filter Translation Layer**
+   - Translate SK filters into LiteDB queries; include coverage for supported operators.
+6. **Testing**
+   - Unit and integration tests plus concurrency and delete-reclamation validation (file size assertions via temporary database file growth/shrink behavior).
+7. **Documentation & Samples**
+   - Update docs, add sample console app demonstrating ingestion and similarity search.
+8. **CI Integration**
+   - Ensure tests run in existing pipelines, add necessary LiteDB temporary file cleanup, and document prerequisites.
+
+## Risks & Mitigations
+- **Prerelease Dependency Instability**: LiteDB vector APIs may change before GA. Mitigate by isolating usage behind adapters and tracking release updates.
+- **Sync API Throughput**: Because LiteDB lacks async APIs, high-concurrency workloads may face contention. Mitigate by batching operations, documenting best practices, and considering background ingestion pipelines.
+- **Filter Parity**: Achieving full filter compatibility may require iterative development. Start with core operators and capture backlog items for advanced scenarios.
+- **File Locking on Multiple Processes**: LiteDB is single-process. Document this limitation and provide detection to throw informative errors if connection fails.
+
+## Open Questions
+- Should the connector ship with optional encryption support leveraging LiteDB's password-protected files?
+- Do we need migration tooling if LiteDB modifies index metadata between prereleases?
+- Is there appetite for a cross-platform sample showing offline RAG using LiteDB for distribution with SK demos?
+
+## References
+- LiteDB v6.0 prerelease #52 release notes highlighting vector search, HNSW index, and SQL support.
+- Semantic Kernel issue #13224 proposing LiteDB connector and motivating advantages (managed dependency, reliable deletes, HNSW performance).

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -217,6 +217,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageVersion Include="LiteDB" Version="6.0.0-prerelease.63" />
     <!-- OnnxRuntimeGenAI -->
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.8.3" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI.Cuda" Version="0.8.1" />

--- a/dotnet/SK-dotnet.slnx
+++ b/dotnet/SK-dotnet.slnx
@@ -147,6 +147,7 @@
     <Project Path="src/VectorData/CosmosMongoDB/CosmosMongoDB.csproj" />
     <Project Path="src/VectorData/CosmosNoSql/CosmosNoSql.csproj" />
     <Project Path="src/VectorData/InMemory/InMemory.csproj" />
+    <Project Path="src/VectorData/LiteDb/LiteDb.csproj" />
     <Project Path="src/VectorData/Milvus/Milvus.csproj" />
     <Project Path="src/VectorData/MongoDB/MongoDB.csproj" />
     <Project Path="src/VectorData/PgVector/PgVector.csproj" />
@@ -322,6 +323,7 @@
     <Project Path="test/VectorData/CosmosNoSql.UnitTests/CosmosNoSql.UnitTests.csproj" />
     <Project Path="test/VectorData/InMemory.ConformanceTests/InMemory.ConformanceTests.csproj" />
     <Project Path="test/VectorData/InMemory.UnitTests/InMemory.UnitTests.csproj" />
+    <Project Path="test/VectorData/LiteDb.UnitTests/LiteDb.UnitTests.csproj" />
     <Project Path="test/VectorData/MongoDB.ConformanceTests/MongoDB.ConformanceTests.csproj" />
     <Project Path="test/VectorData/MongoDB.UnitTests/MongoDB.UnitTests.csproj" />
     <Project Path="test/VectorData/PgVector.ConformanceTests/PgVector.ConformanceTests.csproj" />

--- a/dotnet/src/VectorData/LiteDb/AssemblyInfo.cs
+++ b/dotnet/src/VectorData/LiteDb/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SemanticKernel.Connectors.LiteDb.UnitTests")]

--- a/dotnet/src/VectorData/LiteDb/LiteDb.csproj
+++ b/dotnet/src/VectorData/LiteDb/LiteDb.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Microsoft.SemanticKernel.Connectors.LiteDb</AssemblyName>
+    <RootNamespace>$(AssemblyName)</RootNamespace>
+    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+    <VersionSuffix>preview</VersionSuffix>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+  <Import Project="$(RepoRoot)/dotnet/src/InternalUtilities/src/RestrictedInternalUtilities.props" />
+
+  <PropertyGroup>
+    <Title>LiteDB provider for Microsoft.Extensions.VectorData</Title>
+    <Description>LiteDB provider for Microsoft.Extensions.VectorData by Semantic Kernel</Description>
+    <PackageReadmeFile>VECTORDATA-CONNECTORS-NUGET.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(RepoRoot)/dotnet/nuget/VECTORDATA-CONNECTORS-NUGET.md" Link="VECTORDATA-CONNECTORS-NUGET.md" Pack="true" PackagePath="." />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LiteDB" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VectorData.Abstractions\VectorData.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/VectorData/LiteDb/LiteDbCollection.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbCollection.cs
@@ -1,0 +1,373 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteDB;
+using LiteDB.Vector;
+using Microsoft.Extensions.VectorData;
+using Microsoft.Extensions.VectorData.ProviderServices;
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public class LiteDbCollection<TKey, TRecord> : VectorStoreCollection<TKey, TRecord>
+#pragma warning restore CA1711
+    where TKey : notnull
+    where TRecord : class
+{
+    private readonly LiteDatabase _database;
+    private readonly string _collectionName;
+    private readonly LiteDbVectorStoreOptions _storeOptions;
+    private readonly LiteDbCollectionOptions _collectionOptions;
+    private readonly CollectionModel _model;
+    private readonly LiteDbRecordMapper<TRecord> _mapper;
+    private readonly VectorStoreCollectionMetadata _metadata;
+
+    private static readonly VectorSearchOptions<TRecord> s_defaultSearchOptions = new();
+
+    public LiteDbCollection(LiteDatabase database, string collectionName, LiteDbVectorStoreOptions storeOptions, LiteDbCollectionOptions? collectionOptions = null)
+        : this(database, collectionName, storeOptions, collectionOptions, modelFactory: options =>
+        {
+            if (typeof(TRecord) == typeof(Dictionary<string, object?>))
+            {
+                throw new NotSupportedException(VectorDataStrings.NonDynamicCollectionWithDictionaryNotSupported(typeof(LiteDbDynamicCollection)));
+            }
+
+            return new LiteDbModelBuilder().Build(typeof(TRecord), options.Definition, options.EmbeddingGenerator);
+        })
+    {
+    }
+
+    internal LiteDbCollection(LiteDatabase database, string collectionName, LiteDbVectorStoreOptions storeOptions, LiteDbCollectionOptions? collectionOptions, Func<LiteDbCollectionOptions, CollectionModel> modelFactory)
+    {
+        Verify.NotNull(database);
+        Verify.NotNullOrWhiteSpace(collectionName);
+
+        this._database = database;
+        this._collectionName = collectionName;
+        this._storeOptions = storeOptions;
+        this._collectionOptions = collectionOptions ?? new LiteDbCollectionOptions();
+        this._model = modelFactory(this._collectionOptions);
+        this._mapper = new LiteDbRecordMapper<TRecord>(this._model);
+        this._metadata = new()
+        {
+            VectorStoreSystemName = LiteDbConstants.VectorStoreSystemName,
+            CollectionName = collectionName
+        };
+    }
+
+    public override string Name => this._collectionName;
+
+    public override Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(this._database.CollectionExists(this._collectionName));
+
+    public override Task EnsureCollectionExistsAsync(CancellationToken cancellationToken = default)
+    {
+        var collection = this.GetCollection();
+
+        if (this._storeOptions.AutoCreateVectorIndexes)
+        {
+            foreach (var vectorProperty in this._model.VectorProperties)
+            {
+                if (vectorProperty.Dimensions <= 0)
+                {
+                    throw new InvalidOperationException($"Vector property '{vectorProperty.ModelName}' must specify a dimension when creating LiteDB collections.");
+                }
+
+                var metric = LiteDbVectorMath.ToLiteDbMetric(vectorProperty.DistanceFunction, this._storeOptions.DefaultDistanceMetric);
+                collection.EnsureIndex(vectorProperty.StorageName, new VectorIndexOptions((ushort)vectorProperty.Dimensions, metric));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public override Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default)
+    {
+        this._database.DropCollection(this._collectionName);
+        return Task.CompletedTask;
+    }
+
+    public override Task<TRecord?> GetAsync(TKey key, RecordRetrievalOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(key);
+        options ??= new();
+
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
+        {
+            throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
+        }
+
+        var document = this.GetCollection().FindById(new BsonValue(key));
+        if (document is null)
+        {
+            return Task.FromResult<TRecord?>(null);
+        }
+
+        var record = this._mapper.ToRecord(document, options.IncludeVectors);
+        return Task.FromResult<TRecord?>(record);
+    }
+
+    public override Task DeleteAsync(TKey key, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(key);
+
+        this.GetCollection().Delete(new BsonValue(key));
+        return Task.CompletedTask;
+    }
+
+    public override Task UpsertAsync(TRecord record, CancellationToken cancellationToken = default)
+        => this.UpsertAsync([record], cancellationToken);
+
+    public override Task UpsertAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(records);
+
+        var collection = this.GetCollection();
+
+        if (this._database.BeginTrans())
+        {
+            try
+            {
+                foreach (var record in records)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var document = this._mapper.ToDocument(record);
+                    this.ValidateVectors(document);
+                    collection.Upsert(document);
+                }
+
+                this._database.Commit();
+            }
+            catch
+            {
+                this._database.Rollback();
+                throw;
+            }
+        }
+        else
+        {
+            foreach (var record in records)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var document = this._mapper.ToDocument(record);
+                this.ValidateVectors(document);
+                collection.Upsert(document);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public override async IAsyncEnumerable<TRecord> GetAsync(Expression<Func<TRecord, bool>> filter, int top, FilteredRecordRetrievalOptions<TRecord>? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(filter);
+        Verify.NotLessThan(top, 1);
+        options ??= new();
+
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
+        {
+            throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
+        }
+
+        if (options.OrderBy is not null)
+        {
+            throw new NotSupportedException("LiteDB connector does not currently support ordered filtered retrieval.");
+        }
+
+        var compiled = filter.Compile();
+        var includeVectors = options.IncludeVectors;
+        var skip = options.Skip;
+        var returned = 0;
+
+        foreach (var document in this.GetCollection().FindAll())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var record = this._mapper.ToRecord(document, includeVectors);
+
+            if (!compiled(record))
+            {
+                continue;
+            }
+
+            if (skip > 0)
+            {
+                skip--;
+                continue;
+            }
+
+            yield return record;
+            returned++;
+
+            if (returned >= top)
+            {
+                yield break;
+            }
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    public override async IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(TInput searchValue, int top, VectorSearchOptions<TRecord>? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Verify.NotLessThan(top, 1);
+        options ??= s_defaultSearchOptions;
+
+        if (options.IncludeVectors && this._model.EmbeddingGenerationRequired)
+        {
+            throw new NotSupportedException(VectorDataStrings.IncludeVectorsNotSupportedWithEmbeddingGeneration);
+        }
+
+        var vectorProperty = this._model.GetVectorPropertyOrSingle(options);
+        var searchVector = this.GetVectorFromInput(searchValue, vectorProperty);
+        var includeVectors = options.IncludeVectors;
+        var skip = options.Skip;
+        var distanceFunction = vectorProperty.DistanceFunction;
+
+        List<(TRecord Record, double Score)> scoredResults;
+
+        if (options.Filter is not null)
+        {
+            scoredResults = this.SearchWithFilter(options.Filter, searchVector, vectorProperty, includeVectors, cancellationToken);
+        }
+        else
+        {
+            scoredResults = this.SearchWithVectorIndex(searchVector, vectorProperty, includeVectors, skip + top, cancellationToken);
+        }
+
+        var ordered = LiteDbVectorMath.ShouldSortDescending(distanceFunction)
+            ? scoredResults.OrderByDescending(result => result.Score)
+            : scoredResults.OrderBy(result => result.Score);
+
+        var enumerated = ordered.Skip(skip).Take(top);
+
+        foreach (var result in enumerated)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new VectorSearchResult<TRecord>(result.Record, result.Score);
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    public override object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        Verify.NotNull(serviceType);
+
+        if (serviceKey is not null)
+        {
+            return null;
+        }
+
+        if (serviceType.IsInstanceOfType(this))
+        {
+            return this;
+        }
+
+        if (serviceType == typeof(VectorStoreCollectionMetadata))
+        {
+            return this._metadata;
+        }
+
+        return null;
+    }
+
+    protected ILiteCollection<BsonDocument> GetCollection()
+        => this._database.GetCollection<BsonDocument>(this._collectionName);
+
+    private void ValidateVectors(BsonDocument document)
+    {
+        foreach (var vectorProperty in this._model.VectorProperties)
+        {
+            if (!document.TryGetValue(vectorProperty.StorageName, out var value))
+            {
+                throw new InvalidOperationException($"Vector property '{vectorProperty.ModelName}' must be provided.");
+            }
+
+            if (!value.IsVector)
+            {
+                throw new InvalidOperationException($"Field '{vectorProperty.StorageName}' must contain a vector.");
+            }
+
+            var vector = (float[])value.RawValue;
+            if (vectorProperty.Dimensions > 0 && vector.Length != vectorProperty.Dimensions)
+            {
+                throw new InvalidOperationException($"Vector property '{vectorProperty.ModelName}' expected {vectorProperty.Dimensions} dimensions but received {vector.Length}.");
+            }
+        }
+    }
+
+    private List<(TRecord Record, double Score)> SearchWithVectorIndex(ReadOnlyMemory<float> searchVector, VectorPropertyModel vectorProperty, bool includeVectors, int limit, CancellationToken cancellationToken)
+    {
+        var collection = this.GetCollection();
+        var results = new List<(TRecord Record, double Score)>();
+        var vectorField = vectorProperty.StorageName;
+
+        foreach (var document in collection.Query().TopKNear(vectorField, searchVector.ToArray(), limit).ToDocuments())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!document.TryGetValue(vectorField, out var value) || !value.IsVector)
+            {
+                continue;
+            }
+
+            var candidateVector = (float[])value.RawValue;
+            var record = this._mapper.ToRecord(document, includeVectors);
+            var comparison = LiteDbVectorMath.Compare(searchVector.Span, candidateVector, vectorProperty.DistanceFunction);
+            var score = LiteDbVectorMath.ConvertScore(comparison, vectorProperty.DistanceFunction);
+            results.Add((record, score));
+        }
+
+        return results;
+    }
+
+    private List<(TRecord Record, double Score)> SearchWithFilter(Expression<Func<TRecord, bool>> filter, ReadOnlyMemory<float> searchVector, VectorPropertyModel vectorProperty, bool includeVectors, CancellationToken cancellationToken)
+    {
+        var compiled = filter.Compile();
+        var results = new List<(TRecord Record, double Score)>();
+        var vectorField = vectorProperty.StorageName;
+
+        foreach (var document in this.GetCollection().FindAll())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!document.TryGetValue(vectorField, out var value) || !value.IsVector)
+            {
+                continue;
+            }
+
+            var record = this._mapper.ToRecord(document, includeVectors);
+            if (!compiled(record))
+            {
+                continue;
+            }
+
+            var candidateVector = (float[])value.RawValue;
+            var comparison = LiteDbVectorMath.Compare(searchVector.Span, candidateVector, vectorProperty.DistanceFunction);
+            var score = LiteDbVectorMath.ConvertScore(comparison, vectorProperty.DistanceFunction);
+            results.Add((record, score));
+        }
+
+        return results;
+    }
+
+    private ReadOnlyMemory<float> GetVectorFromInput<TInput>(TInput searchValue, VectorPropertyModel vectorProperty)
+    {
+        switch (searchValue)
+        {
+            case ReadOnlyMemory<float> memory:
+                return memory;
+            case float[] array:
+                return new ReadOnlyMemory<float>(array);
+            case IEnumerable<float> enumerable:
+                return new ReadOnlyMemory<float>(enumerable.ToArray());
+            default:
+                throw new NotSupportedException($"Search input type '{typeof(TInput).Name}' is not supported by the LiteDB connector.");
+        }
+    }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbCollectionOptions.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbCollectionOptions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.VectorData;
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+/// <summary>
+/// Options used when creating a <see cref="LiteDbCollection{TKey, TRecord}"/>.
+/// </summary>
+public sealed class LiteDbCollectionOptions
+{
+    /// <summary>
+    /// Gets or sets the optional collection definition describing how the record type maps to LiteDB.
+    /// </summary>
+    public VectorStoreCollectionDefinition? Definition { get; set; }
+
+    /// <summary>
+    /// Gets or sets the embedding generator to use for vector properties when the record definition relies on generated vectors.
+    /// </summary>
+    public IEmbeddingGenerator? EmbeddingGenerator { get; set; }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbConstants.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbConstants.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+internal static class LiteDbConstants
+{
+    internal const string VectorStoreSystemName = "LiteDB";
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbDynamicCollection.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbDynamicCollection.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using LiteDB;
+using Microsoft.Extensions.VectorData.ProviderServices;
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+internal sealed class LiteDbDynamicCollection : LiteDbCollection<object, Dictionary<string, object?>>
+{
+    public LiteDbDynamicCollection(LiteDatabase database, string collectionName, LiteDbVectorStoreOptions storeOptions, LiteDbCollectionOptions? collectionOptions)
+        : base(database, collectionName, storeOptions, collectionOptions, modelFactory: options =>
+        {
+            if (options.Definition is null)
+            {
+                throw new ArgumentException("A record definition must be supplied for dynamic collections.");
+            }
+
+            return new LiteDbModelBuilder().BuildDynamic(options.Definition, options.EmbeddingGenerator);
+        })
+    {
+    }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbModelBuilder.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbModelBuilder.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.VectorData.ProviderServices;
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+internal sealed class LiteDbModelBuilder() : CollectionModelBuilder(ValidationOptions)
+{
+    private const string SupportedVectorTypes = "ReadOnlyMemory<float>, float[]";
+
+    internal static readonly CollectionModelBuildingOptions ValidationOptions = new()
+    {
+        RequiresAtLeastOneVector = false,
+        SupportsMultipleKeys = false,
+        SupportsMultipleVectors = true
+    };
+
+    protected override bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
+    {
+        supportedTypes = "string";
+        return type == typeof(string);
+    }
+
+    protected override bool IsDataPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
+    {
+        supportedTypes = "";
+        return true;
+    }
+
+    protected override bool IsVectorPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
+    {
+        supportedTypes = SupportedVectorTypes;
+
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
+        return type == typeof(ReadOnlyMemory<float>)
+            || type == typeof(float[]);
+    }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbRecordMapper.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbRecordMapper.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using LiteDB;
+using Microsoft.Extensions.VectorData.ProviderServices;
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+internal sealed class LiteDbRecordMapper<TRecord>
+    where TRecord : class
+{
+    private readonly CollectionModel _model;
+
+    public LiteDbRecordMapper(CollectionModel model)
+    {
+        this._model = model;
+    }
+
+    public BsonDocument ToDocument(TRecord record)
+    {
+        var document = new BsonDocument();
+        var key = this._model.KeyProperty.GetValueAsObject(record)
+            ?? throw new InvalidOperationException("Vector store records must define a non-null key.");
+
+        document[LiteDbWellKnownFields.Id] = new BsonValue(key);
+
+        foreach (var dataProperty in this._model.DataProperties)
+        {
+            var value = dataProperty.GetValueAsObject(record);
+
+            if (value is null)
+            {
+                continue;
+            }
+
+            document[dataProperty.StorageName] = BsonMapper.Global.Serialize(dataProperty.Type, value);
+        }
+
+        foreach (var vectorProperty in this._model.VectorProperties)
+        {
+            var vector = LiteDbVectorConversion.GetVectorFromRecord(record, vectorProperty);
+            document[vectorProperty.StorageName] = new BsonVector(vector);
+        }
+
+        return document;
+    }
+
+    public TRecord ToRecord(BsonDocument document, bool includeVectors)
+    {
+        var record = this._model.CreateRecord<TRecord>();
+
+        if (document.TryGetValue(LiteDbWellKnownFields.Id, out var keyValue))
+        {
+            this._model.KeyProperty.SetValueAsObject(record, this.ConvertValue(keyValue, this._model.KeyProperty.Type));
+        }
+
+        foreach (var dataProperty in this._model.DataProperties)
+        {
+            if (!document.TryGetValue(dataProperty.StorageName, out var value) || value.IsNull)
+            {
+                continue;
+            }
+
+            var converted = this.ConvertValue(value, dataProperty.Type);
+            dataProperty.SetValueAsObject(record, converted);
+        }
+
+        if (includeVectors)
+        {
+            foreach (var vectorProperty in this._model.VectorProperties)
+            {
+                if (!document.TryGetValue(vectorProperty.StorageName, out var value) || value.IsNull)
+                {
+                    continue;
+                }
+
+                var vector = LiteDbVectorConversion.ConvertVectorToProperty(value, vectorProperty);
+                vectorProperty.SetValueAsObject(record, vector);
+            }
+        }
+
+        return record;
+    }
+
+    private object? ConvertValue(BsonValue value, Type targetType)
+    {
+        targetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+        if (value.IsNull)
+        {
+            return targetType.IsValueType ? Activator.CreateInstance(targetType) : null;
+        }
+
+        if (targetType == typeof(string))
+        {
+            return value.AsString;
+        }
+
+        if (targetType == typeof(int))
+        {
+            return value.AsInt32;
+        }
+
+        if (targetType == typeof(long))
+        {
+            return value.AsInt64;
+        }
+
+        if (targetType == typeof(double))
+        {
+            return value.AsDouble;
+        }
+
+        if (targetType == typeof(float))
+        {
+            return (float)value.AsDouble;
+        }
+
+        if (targetType == typeof(decimal))
+        {
+            return value.AsDecimal;
+        }
+
+        if (targetType == typeof(bool))
+        {
+            return value.AsBoolean;
+        }
+
+        if (targetType == typeof(DateTime))
+        {
+            return value.AsDateTime;
+        }
+
+        if (targetType == typeof(Guid))
+        {
+            return value.AsGuid;
+        }
+
+        if (targetType == typeof(Dictionary<string, object?>))
+        {
+            var dictionary = new Dictionary<string, object?>();
+
+            foreach (var kvp in value.AsDocument)
+            {
+                dictionary[kvp.Key] = this.ConvertValue(kvp.Value, typeof(object));
+            }
+
+            return dictionary;
+        }
+
+        return BsonMapper.Global.Deserialize(targetType, value);
+    }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbVectorConversion.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbVectorConversion.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using LiteDB;
+using Microsoft.Extensions.VectorData.ProviderServices;
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+internal static class LiteDbVectorConversion
+{
+    internal static float[] GetVectorFromRecord<TRecord>(TRecord record, VectorPropertyModel vectorProperty)
+        where TRecord : class
+    {
+        var value = vectorProperty.GetValueAsObject(record)
+            ?? throw new InvalidOperationException($"Vector property '{vectorProperty.ModelName}' must be populated before upserting records.");
+
+        return value switch
+        {
+            ReadOnlyMemory<float> memory => memory.ToArray(),
+            float[] array => array,
+            _ => throw new NotSupportedException($"Vector property '{vectorProperty.ModelName}' is of unsupported type '{value.GetType().Name}'.")
+        };
+    }
+
+    internal static object ConvertVectorToProperty(BsonValue value, VectorPropertyModel vectorProperty)
+    {
+        if (!value.IsVector)
+        {
+            throw new InvalidOperationException($"Field '{vectorProperty.StorageName}' does not contain a LiteDB vector.");
+        }
+
+        var vector = (float[])value.RawValue;
+
+        return vectorProperty.Type == typeof(ReadOnlyMemory<float>) || vectorProperty.Type == typeof(ReadOnlyMemory<float>?)
+            ? new ReadOnlyMemory<float>(vector)
+            : vector;
+    }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbVectorMath.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbVectorMath.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using LiteDB.Vector;
+using Microsoft.Extensions.VectorData;
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+internal static class LiteDbVectorMath
+{
+    internal static double Compare(ReadOnlySpan<float> x, ReadOnlySpan<float> y, string? distanceFunction)
+    {
+        return distanceFunction switch
+        {
+            null => CosineSimilarity(x, y),
+            DistanceFunction.CosineSimilarity => CosineSimilarity(x, y),
+            DistanceFunction.CosineDistance => CosineSimilarity(x, y),
+            DistanceFunction.DotProductSimilarity => DotProduct(x, y),
+            DistanceFunction.EuclideanDistance => EuclideanDistance(x, y),
+            _ => throw new NotSupportedException($"The distance function '{distanceFunction}' is not supported by the LiteDB connector.")
+        };
+    }
+
+    internal static double ConvertScore(double score, string? distanceFunction)
+    {
+        return distanceFunction switch
+        {
+            DistanceFunction.CosineDistance => 1 - score,
+            _ => score
+        };
+    }
+
+    internal static bool ShouldSortDescending(string? distanceFunction)
+    {
+        return distanceFunction switch
+        {
+            null => true,
+            DistanceFunction.CosineSimilarity => true,
+            DistanceFunction.DotProductSimilarity => true,
+            DistanceFunction.CosineDistance => false,
+            DistanceFunction.EuclideanDistance => false,
+            _ => throw new NotSupportedException($"The distance function '{distanceFunction}' is not supported by the LiteDB connector.")
+        };
+    }
+
+    internal static VectorDistanceMetric ToLiteDbMetric(string? distanceFunction, VectorDistanceMetric defaultMetric)
+    {
+        return distanceFunction switch
+        {
+            null => defaultMetric,
+            DistanceFunction.CosineSimilarity => VectorDistanceMetric.Cosine,
+            DistanceFunction.CosineDistance => VectorDistanceMetric.Cosine,
+            DistanceFunction.DotProductSimilarity => VectorDistanceMetric.DotProduct,
+            DistanceFunction.EuclideanDistance => VectorDistanceMetric.Euclidean,
+            _ => defaultMetric
+        };
+    }
+
+    private static double CosineSimilarity(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+    {
+        double dot = 0;
+        double normX = 0;
+        double normY = 0;
+
+        for (int i = 0; i < x.Length && i < y.Length; i++)
+        {
+            var xv = x[i];
+            var yv = y[i];
+            dot += xv * yv;
+            normX += xv * xv;
+            normY += yv * yv;
+        }
+
+        if (normX == 0 || normY == 0)
+        {
+            return 0;
+        }
+
+        return dot / Math.Sqrt(normX * normY);
+    }
+
+    private static double DotProduct(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+    {
+        double dot = 0;
+        for (int i = 0; i < x.Length && i < y.Length; i++)
+        {
+            dot += x[i] * y[i];
+        }
+
+        return dot;
+    }
+
+    private static double EuclideanDistance(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+    {
+        double sum = 0;
+        for (int i = 0; i < x.Length && i < y.Length; i++)
+        {
+            var diff = x[i] - y[i];
+            sum += diff * diff;
+        }
+
+        return Math.Sqrt(sum);
+    }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbVectorStore.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbVectorStore.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteDB;
+using LiteDB.Vector;
+using Microsoft.Extensions.VectorData;
+using Microsoft.Extensions.VectorData.ProviderServices;
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+/// <summary>
+/// LiteDB backed implementation of <see cref="VectorStore"/>.
+/// </summary>
+public sealed class LiteDbVectorStore : VectorStore
+{
+    private readonly LiteDatabase _database = null!;
+    private readonly LiteDbVectorStoreOptions _options;
+    private readonly bool _ownsDatabase;
+
+    private readonly VectorStoreMetadata _metadata;
+
+    public LiteDbVectorStore(LiteDbVectorStoreOptions? options = null)
+    {
+        this._options = options ?? new LiteDbVectorStoreOptions();
+        (this._database, this._ownsDatabase) = CreateDatabase(this._options);
+
+        this._metadata = new()
+        {
+            VectorStoreSystemName = LiteDbConstants.VectorStoreSystemName,
+            VectorStoreName = this._options.ConnectionString
+        };
+    }
+
+    internal LiteDatabase Database => this._database;
+
+    [RequiresDynamicCode("This overload of GetCollection() is incompatible with NativeAOT. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
+    [RequiresUnreferencedCode("This overload of GetCollection() is incompatible with trimming. For dynamic mapping via Dictionary<string, object?>, call GetDynamicCollection() instead.")]
+    public override VectorStoreCollection<TKey, TRecord> GetCollection<TKey, TRecord>(string name, VectorStoreCollectionDefinition? definition = null)
+    {
+        Verify.NotNullOrWhiteSpace(name);
+
+        if (typeof(TKey) != typeof(string))
+        {
+            throw new NotSupportedException("LiteDB vector store collections require string keys.");
+        }
+
+        var options = new LiteDbCollectionOptions
+        {
+            Definition = definition
+        };
+
+        return new LiteDbCollection<TKey, TRecord>(
+            this._database,
+            this.GetPhysicalCollectionName(name),
+            this._options,
+            options);
+    }
+
+    public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition definition)
+    {
+        Verify.NotNullOrWhiteSpace(name);
+        Verify.NotNull(definition);
+
+        var options = new LiteDbCollectionOptions
+        {
+            Definition = definition
+        };
+
+        return new LiteDbDynamicCollection(
+            this._database,
+            this.GetPhysicalCollectionName(name),
+            this._options,
+            options);
+    }
+
+    public override async IAsyncEnumerable<string> ListCollectionNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var collection in this._database.GetCollectionNames())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!string.IsNullOrEmpty(this._options.CollectionNamePrefix) && collection.StartsWith(this._options.CollectionNamePrefix, StringComparison.Ordinal))
+            {
+                yield return collection[this._options.CollectionNamePrefix.Length..];
+            }
+            else if (string.IsNullOrEmpty(this._options.CollectionNamePrefix))
+            {
+                yield return collection;
+            }
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    public override Task<bool> CollectionExistsAsync(string name, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(name);
+
+        var physicalName = this.GetPhysicalCollectionName(name);
+        return Task.FromResult(this._database.CollectionExists(physicalName));
+    }
+
+    public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(name);
+
+        var physicalName = this.GetPhysicalCollectionName(name);
+        this._database.DropCollection(physicalName);
+        return Task.CompletedTask;
+    }
+
+    public override object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        Verify.NotNull(serviceType);
+
+        if (serviceKey is not null)
+        {
+            return null;
+        }
+
+        if (serviceType.IsInstanceOfType(this))
+        {
+            return this;
+        }
+
+        if (serviceType == typeof(VectorStoreMetadata))
+        {
+            return this._metadata;
+        }
+
+        if (serviceType == typeof(LiteDatabase))
+        {
+            return this._database;
+        }
+
+        return null;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && this._ownsDatabase)
+        {
+            this._database.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private static (LiteDatabase database, bool ownsDatabase) CreateDatabase(LiteDbVectorStoreOptions options)
+    {
+        if (options.DatabaseFactory is not null)
+        {
+            return (options.DatabaseFactory(), options.DisposeDatabase);
+        }
+
+        if (string.IsNullOrWhiteSpace(options.ConnectionString))
+        {
+            throw new ArgumentException("A connection string or database factory must be provided.", nameof(options));
+        }
+
+        return (new LiteDatabase(options.ConnectionString), true);
+    }
+
+    private string GetPhysicalCollectionName(string logicalName)
+    {
+        if (string.IsNullOrEmpty(this._options.CollectionNamePrefix))
+        {
+            return logicalName;
+        }
+
+        return this._options.CollectionNamePrefix + logicalName;
+    }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbVectorStoreOptions.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbVectorStoreOptions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using LiteDB;
+using LiteDB.Vector;
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+/// <summary>
+/// Options used to configure <see cref="LiteDbVectorStore"/>.
+/// </summary>
+public sealed class LiteDbVectorStoreOptions
+{
+    /// <summary>
+    /// Gets or sets the LiteDB connection string used to create the underlying <see cref="LiteDatabase"/>.
+    /// </summary>
+    /// <remarks>
+    /// The connection string is required when <see cref="DatabaseFactory"/> is not provided.
+    /// </remarks>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the factory used to create the underlying <see cref="LiteDatabase"/> instance.
+    /// </summary>
+    /// <remarks>
+    /// When specified, <see cref="ConnectionString"/> is ignored. The caller is responsible for configuring the
+    /// <see cref="LiteDatabase"/> with any desired options such as shared connections or logging.
+    /// </remarks>
+    public Func<LiteDatabase>? DatabaseFactory { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the <see cref="LiteDatabase"/> instance should be disposed when the
+    /// <see cref="LiteDbVectorStore"/> is disposed.
+    /// </summary>
+    public bool DisposeDatabase { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets an optional prefix applied to every LiteDB collection name created by the vector store.
+    /// </summary>
+    /// <remarks>
+    /// This can be used to avoid collisions when multiple vector stores share the same database file.
+    /// </remarks>
+    public string CollectionNamePrefix { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the default distance metric used when creating vector indexes.
+    /// </summary>
+    public VectorDistanceMetric DefaultDistanceMetric { get; set; } = VectorDistanceMetric.Cosine;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether vector indexes should be automatically created when a collection is ensured.
+    /// </summary>
+    public bool AutoCreateVectorIndexes { get; set; } = true;
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbWellKnownFields.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbWellKnownFields.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.SemanticKernel.Connectors.LiteDb;
+
+internal static class LiteDbWellKnownFields
+{
+    internal const string Id = "_id";
+}

--- a/dotnet/test/VectorData/LiteDb.UnitTests/LiteDb.UnitTests.csproj
+++ b/dotnet/test/VectorData/LiteDb.UnitTests/LiteDb.UnitTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>SemanticKernel.Connectors.LiteDb.UnitTests</AssemblyName>
+    <RootNamespace>SemanticKernel.Connectors.LiteDb.UnitTests</RootNamespace>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);SKEXP0001,MEVD9001,CA2007,CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\VectorData\LiteDb\LiteDb.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/test/VectorData/LiteDb.UnitTests/LiteDbCollectionTests.cs
+++ b/dotnet/test/VectorData/LiteDb.UnitTests/LiteDbCollectionTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.LiteDb;
+using Xunit;
+
+namespace SemanticKernel.Connectors.LiteDb.UnitTests;
+
+public sealed class LiteDbCollectionTests : IDisposable
+{
+    private readonly string _databasePath;
+    private readonly List<LiteDbVectorStore> _stores = new();
+
+    public LiteDbCollectionTests()
+    {
+        this._databasePath = Path.Combine(Path.GetTempPath(), $"sk-lite-{Guid.NewGuid():N}.db");
+    }
+
+    [Fact]
+    public async Task UpsertAndRetrieveRecordAsync()
+    {
+        var collection = await this.CreateCollectionAsync();
+
+        var record = new TestRecord
+        {
+            Id = "item-1",
+            Title = "First",
+            Tags = ["alpha"],
+            Embedding = new float[] { 0.1f, 0.2f, 0.3f }
+        };
+
+        await collection.UpsertAsync(record);
+
+        var retrieved = await collection.GetAsync("item-1", new RecordRetrievalOptions { IncludeVectors = true });
+
+        Assert.NotNull(retrieved);
+        Assert.Equal("First", retrieved!.Title);
+        Assert.Equal(record.Tags, retrieved.Tags);
+        Assert.True(retrieved.Embedding.Span.SequenceEqual(record.Embedding.Span));
+    }
+
+    [Fact]
+    public async Task SearchReturnsResultsOrderedBySimilarityAsync()
+    {
+        var collection = await this.CreateCollectionAsync();
+
+        await collection.UpsertAsync(new TestRecord
+        {
+            Id = "item-1",
+            Title = "Alpha",
+            Tags = ["a"],
+            Embedding = new float[] { 0.0f, 0.0f, 1.0f }
+        });
+
+        await collection.UpsertAsync(new TestRecord
+        {
+            Id = "item-2",
+            Title = "Beta",
+            Tags = ["b"],
+            Embedding = new float[] { 1.0f, 0.0f, 0.0f }
+        });
+
+        await collection.UpsertAsync(new TestRecord
+        {
+            Id = "item-3",
+            Title = "Gamma",
+            Tags = ["c"],
+            Embedding = new float[] { 0.0f, 1.0f, 0.0f }
+        });
+
+        var results = new List<VectorSearchResult<TestRecord>>();
+        await foreach (var result in collection.SearchAsync(new float[] { 0.0f, 0.0f, 1.0f }, 2))
+        {
+            results.Add(result);
+        }
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("item-1", results[0].Record.Id);
+        Assert.Equal("item-2", results[1].Record.Id);
+        Assert.True(results[0].Score >= results[1].Score);
+    }
+
+    [Fact]
+    public async Task ListCollectionNamesRespectsPrefix()
+    {
+        var options = new LiteDbVectorStoreOptions
+        {
+            ConnectionString = $"Filename={this._databasePath};Connection=direct",
+            CollectionNamePrefix = "sk_"
+        };
+
+        using var store = new LiteDbVectorStore(options);
+        var collection = store.GetCollection<string, TestRecord>("vectors");
+        await collection.EnsureCollectionExistsAsync();
+
+        await foreach (var name in store.ListCollectionNamesAsync())
+        {
+            Assert.Equal("vectors", name);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var store in this._stores)
+        {
+            store.Dispose();
+        }
+
+        try
+        {
+            if (File.Exists(this._databasePath))
+            {
+                File.Delete(this._databasePath);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private async Task<LiteDbCollection<string, TestRecord>> CreateCollectionAsync()
+    {
+        var options = new LiteDbVectorStoreOptions
+        {
+            ConnectionString = $"Filename={this._databasePath};Connection=direct"
+        };
+
+        var store = new LiteDbVectorStore(options);
+        this._stores.Add(store);
+        var collection = (LiteDbCollection<string, TestRecord>)store.GetCollection<string, TestRecord>("records");
+        await collection.EnsureCollectionExistsAsync();
+        return collection;
+    }
+
+    public sealed class TestRecord
+    {
+        [VectorStoreKey]
+        public string Id { get; set; } = string.Empty;
+
+        [VectorStoreData]
+        public string Title { get; set; } = string.Empty;
+
+        [VectorStoreData]
+        public List<string> Tags { get; set; } = new();
+
+        [VectorStoreVector(3, DistanceFunction = DistanceFunction.CosineSimilarity)]
+        public ReadOnlyMemory<float> Embedding { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a LiteDB-backed vector store implementation with options, collection support, and scoring helpers
- register the connector in the solution, document usage, and track progress against the original plan
- create LiteDB unit tests verifying CRUD operations, search ordering, and collection name handling

## Testing
- `dotnet test dotnet/test/VectorData/LiteDb.UnitTests/LiteDb.UnitTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68e51351358c8326a4bbe5cddeaac989