### PR TITLE
Improve LiteDB filter translation and sample coverage

### DIFF
--- a/dotnet/samples/GettingStartedWithVectorStores/GettingStartedWithVectorStores.csproj
+++ b/dotnet/samples/GettingStartedWithVectorStores/GettingStartedWithVectorStores.csproj
@@ -42,6 +42,7 @@
     <ProjectReference Include="..\..\src\Connectors\Connectors.AzureOpenAI\Connectors.AzureOpenAI.csproj" />
     <ProjectReference Include="..\..\src\VectorData\AzureAISearch\AzureAISearch.csproj" />
     <ProjectReference Include="..\..\src\VectorData\InMemory\InMemory.csproj" />
+    <ProjectReference Include="..\..\src\VectorData\LiteDb\LiteDb.csproj" />
     <ProjectReference Include="..\..\src\VectorData\Qdrant\Qdrant.csproj" />
     <ProjectReference Include="..\..\src\VectorData\Redis\Redis.csproj" />
     <ProjectReference Include="..\..\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />

--- a/dotnet/samples/GettingStartedWithVectorStores/README.md
+++ b/dotnet/samples/GettingStartedWithVectorStores/README.md
@@ -4,6 +4,10 @@ This project contains a step by step guide to get started using Vector Stores wi
 
 The examples can be run as integration tests but their code can also be copied to stand-alone programs.
 
+## Step 5 — LiteDB advanced scenario
+
+`Step5_LiteDb_AdvancedScenario` shows how to combine transactional batch upserts, per-property embedding generators and metrics, and the extended filter surface (`Contains`, `StartsWith`, `EndsWith`, `IN`) when working with the LiteDB connector.
+
 ## Configuring Secrets
 
 Most of the examples will require secrets and credentials, to access OpenAI, Azure OpenAI,

--- a/dotnet/samples/GettingStartedWithVectorStores/Step5_LiteDb_AdvancedScenario.cs
+++ b/dotnet/samples/GettingStartedWithVectorStores/Step5_LiteDb_AdvancedScenario.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.LiteDb;
+
+namespace GettingStartedWithVectorStores;
+
+/// <summary>
+/// Demonstrates advanced LiteDB usage: per-property generators and metrics, transactional batch upserts, and expressive filters.
+/// </summary>
+public sealed class Step5_LiteDb_AdvancedScenario(ITestOutputHelper output) : BaseTest(output)
+{
+    private static readonly string[] FilterCities = new[] { "Seattle", "Portland" };
+
+    [Fact]
+    public async Task RunEndToEndScenarioAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(new SampleEmbeddingGenerator("store"));
+        services.AddLiteDbVectorStore(_ => new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            DistanceMetric = LiteDbDistanceMetric.Cosine,
+            AutoCreateVectorIndexes = true,
+            CollectionNamePrefix = "sample_"
+        });
+        services.AddLiteDbCollection<string, SampleHotel>("hotels", _ => new VectorStoreCollectionDefinition
+        {
+            Properties =
+            {
+                new VectorStoreKeyProperty(nameof(SampleHotel.HotelId), typeof(string)),
+                new VectorStoreDataProperty(nameof(SampleHotel.City), typeof(string)),
+                new VectorStoreDataProperty(nameof(SampleHotel.Tags), typeof(List<string>)),
+                new VectorStoreDataProperty(nameof(SampleHotel.Description), typeof(string)),
+                new VectorStoreVectorProperty(nameof(SampleHotel.Overview), typeof(string), 3)
+                {
+                    DistanceFunction = DistanceFunction.DotProductSimilarity,
+                    EmbeddingGenerator = new SampleEmbeddingGenerator("overview")
+                },
+                new VectorStoreVectorProperty(nameof(SampleHotel.Amenities), typeof(string), 3)
+                {
+                    DistanceFunction = DistanceFunction.EuclideanDistance,
+                    EmbeddingGenerator = new SampleEmbeddingGenerator("amenities")
+                }
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var collection = provider.GetRequiredService<VectorStoreCollection<string, SampleHotel>>();
+        await collection.EnsureCollectionExistsAsync();
+
+        var hotels = new[]
+        {
+            new SampleHotel
+            {
+                HotelId = "alpha",
+                City = "Seattle",
+                Description = "Waterfront spa resort",
+                Tags = new List<string> { "spa", "rooftop" },
+                Overview = "0.9,0.05,0.05",
+                Amenities = "0.2,0.5,0.3"
+            },
+            new SampleHotel
+            {
+                HotelId = "beta",
+                City = "Portland",
+                Description = "Modern downtown escape",
+                Tags = new List<string> { "boutique", "spa" },
+                Overview = "0.7,0.1,0.2",
+                Amenities = "0.6,0.2,0.2"
+            },
+            new SampleHotel
+            {
+                HotelId = "gamma",
+                City = "San Francisco",
+                Description = "Historic harbor view",
+                Tags = new List<string> { "historic", "view" },
+                Overview = "0.1,0.8,0.1",
+                Amenities = "0.3,0.1,0.6"
+            }
+        };
+
+        // Batch upsert executes inside a transaction – either all records are stored or none are.
+        await collection.UpsertAsync(hotels);
+
+#pragma warning disable CA1866 // the literal "t" is clearer for sample filtering.
+        var searchOptions = new VectorSearchOptions<SampleHotel>
+        {
+            VectorProperty = h => h.Overview,
+            Filter = h => (h.Tags.Contains("spa") || h.City!.StartsWith("Sea"))
+                && FilterCities.Contains(h.City!)
+                && h.Description!.EndsWith("t"),
+            IncludeVectors = false
+        };
+#pragma warning restore CA1866
+
+        var results = await collection.SearchAsync("0.8,0.1,0.1", top: 2, searchOptions).ToListAsync();
+
+        foreach (var result in results)
+        {
+            this.WriteLine($"Hotel: {result.Record.HotelId} in {result.Record.City} (score {result.Score:F3})");
+        }
+
+        Assert.Single(results);
+        Assert.Equal("alpha", results[0].Record.HotelId);
+    }
+
+    private sealed class SampleHotel
+    {
+        [VectorStoreKey]
+        public string? HotelId { get; set; }
+
+        [VectorStoreData]
+        public string? City { get; set; }
+
+        [VectorStoreData]
+        public string? Description { get; set; }
+
+        [VectorStoreData]
+        public List<string> Tags { get; set; } = new();
+
+        [VectorStoreVector(Dimensions: 3)]
+        public string? Overview { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public string? Amenities { get; set; }
+    }
+
+    private sealed class SampleEmbeddingGenerator(string tag) : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            var embeddings = new GeneratedEmbeddings<Embedding<float>>();
+            foreach (var value in values)
+            {
+                embeddings.Add(new Embedding<float>(ParseVector(value, tag)));
+            }
+
+            return Task.FromResult(embeddings);
+        }
+
+        public Task<Embedding<float>> GenerateAsync(string value, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new Embedding<float>(ParseVector(value, tag)));
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => null;
+
+        public void Dispose()
+        {
+        }
+
+        private static float[] ParseVector(string value, string tagPrefix)
+        {
+            var values = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(float.Parse)
+                .ToArray();
+
+            // Different prefixes allow callers to verify generator precedence in diagnostics.
+            return tagPrefix switch
+            {
+                "overview" => values,
+                _ => values.Select(v => Math.Clamp(v + 0.05f, 0f, 1f)).ToArray()
+            };
+        }
+    }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbCollection.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbCollection.cs
@@ -171,10 +171,35 @@ public class LiteDbCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
         for (var i = 0; i < materialized.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            documents.Add(this._mapper.MapToDocument(materialized[i], generatedVectors, i));
+            var document = this._mapper.MapToDocument(materialized[i], generatedVectors, i);
+            this.ValidateVectorDimensions(document);
+            documents.Add(document);
         }
 
-        this._collection.Upsert(documents);
+        if (documents.Count == 1)
+        {
+            this._collection.Upsert(documents[0]);
+            return;
+        }
+
+        var startedTransaction = this._database.BeginTrans();
+        try
+        {
+            this._collection.Upsert(documents);
+            if (startedTransaction)
+            {
+                this._database.Commit();
+            }
+        }
+        catch
+        {
+            if (startedTransaction)
+            {
+                this._database.Rollback();
+            }
+
+            throw;
+        }
     }
 
     /// <inheritdoc />
@@ -354,4 +379,26 @@ public class LiteDbCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
             LiteDbDistanceMetric.Euclidean => VectorDistanceMetric.Euclidean,
             _ => throw new NotSupportedException($"Unsupported distance metric '{metric}'.")
         };
+
+    private void ValidateVectorDimensions(BsonDocument document)
+    {
+        foreach (var property in this._vectorProperties)
+        {
+            if (!document.TryGetValue(property.StorageName, out var value) || value is not BsonVector vector)
+            {
+                continue;
+            }
+
+            var expectedDimensions = this._options.VectorDimensions ?? property.Dimensions;
+            if (expectedDimensions <= 0)
+            {
+                continue;
+            }
+
+            if (vector.Values.Length != expectedDimensions)
+            {
+                throw new InvalidOperationException($"Vector property '{property.ModelName}' expects {expectedDimensions} dimensions but received {vector.Values.Length}.");
+            }
+        }
+    }
 }

--- a/dotnet/src/VectorData/LiteDb/LiteDbFilterTranslator.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbFilterTranslator.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using LiteDB;
 using Microsoft.Extensions.VectorData.ProviderServices;
 using Microsoft.Extensions.VectorData.ProviderServices.Filter;
@@ -34,6 +37,7 @@ internal sealed class LiteDbFilterTranslator
         {
             null => "true",
             ConstantExpression constant when constant.Value is bool boolValue => boolValue ? "true" : "false",
+            MethodCallExpression method => this.TranslateMethodCall(method),
             BinaryExpression binary when IsComparison(binary.NodeType) => this.TranslateComparison(binary),
             BinaryExpression binary when binary.NodeType is ExpressionType.AndAlso or ExpressionType.OrElse
                 => this.TranslateLogical(binary),
@@ -46,12 +50,12 @@ internal sealed class LiteDbFilterTranslator
 
     private string TranslateComparison(BinaryExpression binary)
     {
-        if (this.TryBindProperty(binary.Left, out var property) && binary.Right is ConstantExpression { Value: var constant })
+        if (this.TryBindProperty(binary.Left, out var property) && this.TryExtractConstant(binary.Right, out var constant))
         {
             return this.GenerateComparison(property, constant, binary.NodeType);
         }
 
-        if (this.TryBindProperty(binary.Right, out property) && binary.Left is ConstantExpression { Value: var leftConstant })
+        if (this.TryBindProperty(binary.Right, out property) && this.TryExtractConstant(binary.Left, out var leftConstant))
         {
             return this.GenerateComparison(property, leftConstant, binary.NodeType);
         }
@@ -80,7 +84,7 @@ internal sealed class LiteDbFilterTranslator
             };
         }
 
-        var placeholder = this.AddParameter(new BsonValue(value));
+        var placeholder = this.AddParameter(this.CreateParameterValue(value));
         var op = nodeType switch
         {
             ExpressionType.Equal => "=",
@@ -95,6 +99,154 @@ internal sealed class LiteDbFilterTranslator
         return $"({field} {op} {placeholder})";
     }
 
+    private string TranslateMethodCall(MethodCallExpression methodCall)
+    {
+        if (methodCall.Method.DeclaringType == typeof(string)
+            && methodCall.Method.Name is nameof(string.Contains) or nameof(string.StartsWith) or nameof(string.EndsWith)
+            && methodCall.Object is { } stringObject
+            && this.TryBindProperty(stringObject, out var stringProperty))
+        {
+            return this.TranslateStringMethod(methodCall, stringProperty);
+        }
+
+        if (methodCall is { Method.Name: nameof(Enumerable.Contains), Method.DeclaringType: var declaringType } enumerableCall
+            && declaringType == typeof(Enumerable))
+        {
+            return this.TranslateEnumerableContains(enumerableCall);
+        }
+
+        if (methodCall.Method.Name == nameof(List<int>.Contains)
+            && methodCall.Object is not null
+            && this.TryBindProperty(methodCall.Object, out var collectionProperty))
+        {
+            return this.TranslateCollectionContains(methodCall, collectionProperty);
+        }
+
+        if (methodCall.Method.Name == "Contains"
+            && methodCall.Object is not null
+            && methodCall.Method.DeclaringType is { } collectionDeclaringType
+            && collectionDeclaringType != typeof(string)
+            && this.TryBindProperty(methodCall.Object, out collectionProperty))
+        {
+            return this.TranslateCollectionContains(methodCall, collectionProperty);
+        }
+
+        throw new NotSupportedException($"Unsupported method call '{methodCall.Method.DeclaringType?.Name}.{methodCall.Method.Name}' in LiteDB filter expression.");
+    }
+
+    private string TranslateStringMethod(MethodCallExpression methodCall, PropertyModel property)
+    {
+        var propertyType = Nullable.GetUnderlyingType(property.Type) ?? property.Type;
+        if (propertyType != typeof(string))
+        {
+            throw new NotSupportedException($"String method '{methodCall.Method.Name}' is only supported on string properties, but '{property.ModelName}' is of type '{property.Type.Name}'.");
+        }
+
+        if (methodCall.Arguments.Count == 0)
+        {
+            throw new NotSupportedException($"Method '{methodCall.Method.Name}' on property '{property.ModelName}' must specify a value argument.");
+        }
+
+        if (methodCall.Arguments.Count > 1)
+        {
+            throw new NotSupportedException($"LiteDB filters only support the overload of '{methodCall.Method.Name}' with a single value argument.");
+        }
+
+        if (!this.TryExtractConstant(methodCall.Arguments[0], out var value) || value is not string stringValue)
+        {
+            throw new NotSupportedException($"LiteDB filters require '{methodCall.Method.Name}' arguments to be constant strings.");
+        }
+
+        var pattern = methodCall.Method.Name switch
+        {
+            nameof(string.Contains) => $"%{EscapeLikePattern(stringValue)}%",
+            nameof(string.StartsWith) => $"{EscapeLikePattern(stringValue)}%",
+            nameof(string.EndsWith) => $"%{EscapeLikePattern(stringValue)}",
+            _ => throw new NotSupportedException($"Unsupported string method '{methodCall.Method.Name}'.")
+        };
+
+        var placeholder = this.AddParameter(new BsonValue(pattern));
+        var field = GetField(property);
+        return $"({field} LIKE {placeholder})";
+    }
+
+    private string TranslateCollectionContains(MethodCallExpression methodCall, PropertyModel property)
+    {
+        if (!typeof(IEnumerable).IsAssignableFrom((Nullable.GetUnderlyingType(property.Type) ?? property.Type)))
+        {
+            throw new NotSupportedException($"Collection.Contains is only supported for enumerable properties. Property '{property.ModelName}' has type '{property.Type.Name}'.");
+        }
+
+        if (methodCall.Arguments.Count != 1)
+        {
+            throw new NotSupportedException($"Method '{methodCall.Method.Name}' must have exactly one argument in LiteDB filters.");
+        }
+
+        if (!this.TryExtractConstant(methodCall.Arguments[0], out var value))
+        {
+            throw new NotSupportedException("LiteDB filters require collection.Contains arguments to be constant values.");
+        }
+
+        var placeholder = this.AddParameter(this.CreateParameterValue(value));
+        var field = GetField(property);
+        return $"({field} ANY = {placeholder})";
+    }
+
+    private string TranslateEnumerableContains(MethodCallExpression methodCall)
+    {
+        if (methodCall.Arguments.Count != 2)
+        {
+            throw new NotSupportedException("Enumerable.Contains must specify the source and the item to compare.");
+        }
+
+        var source = methodCall.Arguments[0];
+        var item = methodCall.Arguments[1];
+
+        if (this.TryBindProperty(source, out var collectionProperty))
+        {
+            var propertyType = Nullable.GetUnderlyingType(collectionProperty.Type) ?? collectionProperty.Type;
+            if (!typeof(IEnumerable).IsAssignableFrom(propertyType))
+            {
+                throw new NotSupportedException($"Enumerable.Contains is only supported on enumerable properties. Property '{collectionProperty.ModelName}' has type '{collectionProperty.Type.Name}'.");
+            }
+
+            if (!this.TryExtractConstant(item, out var element))
+            {
+                throw new NotSupportedException("LiteDB filters require Enumerable.Contains item arguments to be constant values when the source is a record property.");
+            }
+
+            var collectionPlaceholder = this.AddParameter(this.CreateParameterValue(element));
+            var collectionField = GetField(collectionProperty);
+            return $"({collectionField} ANY = {collectionPlaceholder})";
+        }
+
+        if (!this.TryExtractConstant(source, out var values))
+        {
+            try
+            {
+                values = Expression.Lambda(source).Compile().DynamicInvoke();
+            }
+            catch
+            {
+                throw new NotSupportedException("LiteDB filters require Enumerable.Contains sources to be constant sequences.");
+            }
+        }
+
+        if (values is not IEnumerable enumerable)
+        {
+            throw new NotSupportedException("LiteDB filters require Enumerable.Contains sources to be constant sequences.");
+        }
+
+        if (!this.TryBindProperty(item, out var property))
+        {
+            throw new NotSupportedException("LiteDB filters support Enumerable.Contains only when comparing against a record property.");
+        }
+
+        var placeholder = this.AddParameter(this.CreateParameterValue(enumerable));
+        var field = GetField(property);
+        return $"({field} IN {placeholder})";
+    }
+
     private string AddParameter(BsonValue value)
     {
         var index = this._parameters.Count;
@@ -102,10 +254,102 @@ internal sealed class LiteDbFilterTranslator
         return $"@{index}";
     }
 
+    private bool TryExtractConstant(Expression expression, out object? value)
+    {
+        switch (expression)
+        {
+            case ConstantExpression constant:
+                value = constant.Value;
+                return true;
+            case QueryParameterExpression queryParameter:
+                value = queryParameter.Value;
+                return true;
+            case MemberExpression { Expression: QueryParameterExpression queryParameter, Member: PropertyInfo property }
+                when property.CanRead:
+                value = property.GetValue(queryParameter);
+                return true;
+            case MemberExpression { Expression: { } instanceExpression } member
+                when this.TryExtractConstant(instanceExpression, out var instance)
+                && TryGetMemberValue(member.Member, instance, out value):
+                return true;
+            case MemberExpression { Expression: null } member when TryGetMemberValue(member.Member, null, out value):
+                return true;
+            case UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary
+                when this.TryExtractConstant(unary.Operand, out var operand):
+                value = operand;
+                return true;
+            case NewArrayExpression newArray:
+            {
+                var items = new object?[newArray.Expressions.Count];
+                for (var i = 0; i < newArray.Expressions.Count; i++)
+                {
+                    if (!this.TryExtractConstant(newArray.Expressions[i], out var element))
+                    {
+                        value = null;
+                        return false;
+                    }
+
+                    items[i] = element;
+                }
+
+                value = items;
+                return true;
+            }
+            default:
+                value = null;
+                return false;
+        }
+    }
+
+    private BsonValue CreateParameterValue(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                return BsonValue.Null;
+            case BsonValue bson:
+                return bson;
+            case IEnumerable enumerable when value is not string:
+            {
+                var array = new BsonArray();
+                foreach (var element in enumerable)
+                {
+                    array.Add(this.CreateParameterValue(element));
+                }
+
+                return array;
+            }
+            default:
+                return new BsonValue(value);
+        }
+    }
+
+    private static string GetField(PropertyModel property)
+        => $"$.{property.StorageName}";
+
+    private static string EscapeLikePattern(string value)
+        => value.Replace("%", "[%]").Replace("_", "[_]");
+
     private static bool IsComparison(ExpressionType type)
         => type is ExpressionType.Equal or ExpressionType.NotEqual
             or ExpressionType.GreaterThan or ExpressionType.GreaterThanOrEqual
             or ExpressionType.LessThan or ExpressionType.LessThanOrEqual;
+
+    private static bool TryGetMemberValue(MemberInfo member, object? instance, out object? value)
+    {
+        switch (member)
+        {
+            case FieldInfo field:
+                value = field.GetValue(instance);
+                return true;
+            case PropertyInfo { CanRead: true } property:
+                value = property.GetValue(instance);
+                return true;
+            default:
+                value = null;
+                return false;
+        }
+    }
 
     private bool TryBindProperty(Expression expression, [NotNullWhen(true)] out PropertyModel? property)
     {

--- a/dotnet/src/VectorData/LiteDb/LiteDbMapper.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbMapper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.VectorData.ProviderServices;
@@ -29,6 +30,18 @@ internal sealed class LiteDbMapper<TRecord>(CollectionModel model)
             var value = property.GetValueAsObject(record);
             if (value is null)
             {
+                continue;
+            }
+
+            if (value is IEnumerable enumerable && value is not string)
+            {
+                var array = new BsonArray();
+                foreach (var element in enumerable)
+                {
+                    array.Add(element is null ? BsonValue.Null : new BsonValue(element));
+                }
+
+                document[property.StorageName] = array;
                 continue;
             }
 
@@ -135,6 +148,36 @@ internal sealed class LiteDbMapper<TRecord>(CollectionModel model)
         if (underlyingType == typeof(string))
         {
             return value.AsString;
+        }
+
+        if (value.IsArray)
+        {
+            var array = value.AsArray;
+
+            if (underlyingType.IsArray)
+            {
+                var elementType = underlyingType.GetElementType() ?? typeof(object);
+                var result = Array.CreateInstance(elementType, array.Count);
+                for (var i = 0; i < array.Count; i++)
+                {
+                    result.SetValue(ConvertValue(array[i], elementType), i);
+                }
+
+                return result;
+            }
+
+            if (typeof(IList).IsAssignableFrom(underlyingType) && underlyingType.IsGenericType)
+            {
+                var elementType = underlyingType.GetGenericArguments()[0];
+                var listType = typeof(List<>).MakeGenericType(elementType);
+                var list = (IList)Activator.CreateInstance(listType)!;
+                foreach (var item in array)
+                {
+                    list.Add(ConvertValue(item, elementType));
+                }
+
+                return list;
+            }
         }
 
         if (underlyingType == typeof(int))

--- a/dotnet/src/VectorData/LiteDb/LiteDbVectorStore.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbVectorStore.cs
@@ -185,27 +185,14 @@ public sealed class LiteDbVectorStore : VectorStore
             throw new ArgumentException("Connection string cannot be null or whitespace.", nameof(connectionString));
         }
 
-        if (options is not null && (options.Database is not null || options.DatabaseFactory is not null))
-        {
-            throw new ArgumentException("When providing a connection string do not supply an existing LiteDatabase or database factory via options.", nameof(options));
-        }
-
-        var normalized = new LiteDbVectorStoreOptions(options)
-        {
-            ConnectionString = connectionString
-        };
-
+        var normalized = new LiteDbVectorStoreOptions(options);
+        normalized.ConnectionString = connectionString;
         return normalized;
     }
 
     private static LiteDbVectorStoreOptions NormalizeDatabaseOptions(LiteDatabase database, LiteDbVectorStoreOptions? options)
     {
         ArgumentNullException.ThrowIfNull(database);
-
-        if (options is not null && options.DatabaseFactory is not null)
-        {
-            throw new ArgumentException("When providing a LiteDatabase instance do not supply a database factory via options.", nameof(options));
-        }
 
         var normalized = new LiteDbVectorStoreOptions(options)
         {
@@ -217,16 +204,6 @@ public sealed class LiteDbVectorStore : VectorStore
 
     private static (LiteDatabase Database, bool OwnsDatabase, string ConnectionIdentifier) ResolveDatabase(LiteDbVectorStoreOptions options)
     {
-        if (options.Database is not null && options.DatabaseFactory is not null)
-        {
-            throw new ArgumentException("Specify either Database or DatabaseFactory but not both.", nameof(options));
-        }
-
-        if (options.Database is not null)
-        {
-            return (options.Database, options.DisposeDatabase, LiteDbConstants.VectorStoreSystemName);
-        }
-
         if (options.DatabaseFactory is not null)
         {
             var database = options.DatabaseFactory();
@@ -236,6 +213,11 @@ public sealed class LiteDbVectorStore : VectorStore
             }
 
             return (database, options.DisposeDatabase, LiteDbConstants.VectorStoreSystemName);
+        }
+
+        if (options.Database is not null)
+        {
+            return (options.Database, options.DisposeDatabase, LiteDbConstants.VectorStoreSystemName);
         }
 
         var connectionString = string.IsNullOrWhiteSpace(options.ConnectionString)

--- a/dotnet/src/VectorData/LiteDb/LiteDbVectorStoreOptions.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbVectorStoreOptions.cs
@@ -12,6 +12,8 @@ namespace Microsoft.SemanticKernel.Connectors.LiteDb;
 public sealed class LiteDbVectorStoreOptions
 {
     internal static readonly LiteDbVectorStoreOptions Default = new();
+    private bool _autoEnsureVectorIndex = true;
+    private bool? _autoCreateVectorIndexes;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LiteDbVectorStoreOptions"/> class.
@@ -33,6 +35,7 @@ public sealed class LiteDbVectorStoreOptions
         this.DisposeDatabase = source.DisposeDatabase;
         this.DistanceMetric = source.DistanceMetric;
         this.AutoEnsureVectorIndex = source.AutoEnsureVectorIndex;
+        this.AutoCreateVectorIndexes = source.AutoCreateVectorIndexes;
         this.EmbeddingGenerator = source.EmbeddingGenerator;
         this.CollectionNamePrefix = source.CollectionNamePrefix;
     }
@@ -74,7 +77,31 @@ public sealed class LiteDbVectorStoreOptions
     /// <summary>
     /// Gets or sets a value indicating whether collections created through this store automatically ensure their vector index.
     /// </summary>
-    public bool AutoEnsureVectorIndex { get; set; } = true;
+    public bool AutoEnsureVectorIndex
+    {
+        get => this._autoEnsureVectorIndex;
+        set
+        {
+            this._autoEnsureVectorIndex = value;
+            this._autoCreateVectorIndexes = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether collections created through this store automatically ensure their vector index.
+    /// </summary>
+    public bool? AutoCreateVectorIndexes
+    {
+        get => this._autoCreateVectorIndexes;
+        set
+        {
+            this._autoCreateVectorIndexes = value;
+            if (value.HasValue)
+            {
+                this._autoEnsureVectorIndex = value.Value;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets or sets the default embedding generator to use when generating embeddings for vector properties.

--- a/dotnet/src/VectorData/LiteDb/README.md
+++ b/dotnet/src/VectorData/LiteDb/README.md
@@ -22,6 +22,8 @@ The store can also open a LiteDB database using a connection string. When you pa
 
 When you need the connector to manage the database lifecycle, create the store with `LiteDbVectorStoreOptions`. The options surface supports supplying a database factory and a collection name prefix.
 
+Connection sources are considered in the following order: a configured `DatabaseFactory` is used first, then an existing `LiteDatabase` instance via `Database`, and finally the `ConnectionString` (or the embedded default when none is supplied). The `AutoCreateVectorIndexes` property is an alias for `AutoEnsureVectorIndex` so that existing configuration snippets continue to work unchanged.
+
 ```csharp
 var options = new LiteDbVectorStoreOptions
 {
@@ -57,6 +59,20 @@ await collection.EnsureCollectionExistsAsync();
 
 The connector automatically provisions HNSW vector indexes when `EnsureCollectionExistsAsync` is called and a vector property is present. Distance metrics default to cosine similarity but can be overridden through attributes or `LiteDbCollectionOptions`.
 
+## Filtering
+
+LiteDB filter translation covers the standard comparison operators along with string and set membership helpers. The following table shows a subset of the mappings:
+
+| Semantic Kernel filter | LiteDB predicate |
+| --- | --- |
+| `r => r.Rating >= 4` | `($.Rating >= @0)` |
+| `r => r.City.StartsWith("Sea")` | `($.City LIKE @0)` |
+| `r => r.Description.EndsWith("Inn")` | `($.Description LIKE @0)` |
+| `r => r.Tags.Contains("spa")` | `($.Tags ANY = @0)` |
+| `r => new[] { "Seattle", "Portland" }.Contains(r.City)` | `($.City IN @0)` |
+
+Captured variables are parameterized, and unsupported constructs (such as the `StringComparison` overloads) throw `NotSupportedException` so that filters never silently fall back to client-side evaluation.
+
 ## Generating embeddings on the fly
 
 When a record's vector property is a non-vector type (for example `string` or `DataContent`), configure an `IEmbeddingGenerator` so that LiteDB receives vectors during `UpsertAsync` and vector search:
@@ -72,6 +88,10 @@ var collection = store.GetCollection<string, Article>("articles");
 ```
 
 The store-level generator is inherited by collections, but you can override it per collection via `LiteDbCollectionOptions` or per property through a `VectorStoreCollectionDefinition`.
+
+## Batch upserts and transactions
+
+`UpsertAsync(IEnumerable<TRecord>)` executes inside a LiteDB transaction. Either all documents in the batch are written or an exception is thrown and the collection is left unchanged. Single-record upserts skip the transaction for better throughput.
 
 ## Dependency injection
 
@@ -93,6 +113,12 @@ services.AddLiteDbDynamicCollection("snippets", _ => definition);
 ```
 
 Registered collections automatically resolve a `VectorStoreCollection<TKey, TRecord>` and `IVectorSearchable<TRecord>` backed by the keyed store, and they inherit the embedding generator registered in the DI container when one is not provided in the options.
+
+## Performance considerations
+
+- Index creation happens when `EnsureCollectionExistsAsync` runs. For large collections, schedule this ahead of ingesting data or during maintenance windows.
+- Filters that leverage string operators and `IN` clauses are translated to server-side predicates; prefer them over manual in-memory filtering for better selectivity.
+- Vectors are validated at write time so that accidental dimension mismatches are caught before they reach storage.
 
 ## Dynamic collections
 

--- a/dotnet/test/VectorData/LiteDb.UnitTests/LiteDbFilterTranslatorTests.cs
+++ b/dotnet/test/VectorData/LiteDb.UnitTests/LiteDbFilterTranslatorTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.LiteDb;
+using Xunit;
+
+namespace SemanticKernel.Connectors.LiteDb.UnitTests;
+
+public sealed class LiteDbFilterTranslatorTests
+{
+    [Fact]
+    public void TranslatesStringAndMembershipOperators()
+    {
+        var builder = new LiteDbModelBuilder();
+        var model = builder.Build(typeof(FilterHotel), definition: null, defaultEmbeddingGenerator: null);
+        Expression<Func<FilterHotel, bool>> filter = h =>
+            (h.Tags.Contains("spa") || h.City.StartsWith("Sea"))
+            && new[] { "Seattle", "Portland" }.Contains(h.City)
+            && h.Description.EndsWith("Inn");
+
+        var translator = new LiteDbFilterTranslator();
+        var (expression, parameters) = translator.Translate(filter, model);
+
+        Assert.Equal("(((($.Tags ANY = @0) OR ($.City LIKE @1)) AND ($.City IN @2)) AND ($.Description LIKE @3))", expression);
+        Assert.Collection(parameters,
+            p => Assert.Equal("spa", p.AsString),
+            p => Assert.Equal("Sea%", p.AsString),
+            p =>
+            {
+                var array = p.AsArray;
+                Assert.Equal(2, array.Count);
+                Assert.Equal("Seattle", array[0].AsString);
+                Assert.Equal("Portland", array[1].AsString);
+            },
+            p => Assert.Equal("%Inn", p.AsString));
+    }
+
+    [Fact]
+    public void ThrowsHelpfulErrorForUnsupportedStringComparison()
+    {
+        var builder = new LiteDbModelBuilder();
+        var model = builder.Build(typeof(FilterHotel), definition: null, defaultEmbeddingGenerator: null);
+        Expression<Func<FilterHotel, bool>> filter = h => h.City.StartsWith("Sea", StringComparison.OrdinalIgnoreCase);
+
+        var translator = new LiteDbFilterTranslator();
+        var exception = Assert.Throws<NotSupportedException>(() => translator.Translate(filter, model));
+        Assert.Contains("single value argument", exception.Message);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated via reflection during model binding.")]
+    private sealed class FilterHotel
+    {
+        [VectorStoreKey]
+        public string Id { get; set; } = string.Empty;
+
+        [VectorStoreData]
+        public string[] Tags { get; set; } = Array.Empty<string>();
+
+        [VectorStoreData]
+        public string City { get; set; } = string.Empty;
+
+        [VectorStoreData]
+        public string Description { get; set; } = string.Empty;
+
+        [VectorStoreVector(Dimensions: 3)]
+        public ReadOnlyMemory<float>? Embedding { get; set; }
+    }
+}

--- a/dotnet/test/VectorData/LiteDb.UnitTests/LiteDbVectorStoreTests.cs
+++ b/dotnet/test/VectorData/LiteDb.UnitTests/LiteDbVectorStoreTests.cs
@@ -65,8 +65,14 @@ public sealed class LiteDbVectorStoreTests
         }
 
         Assert.Equal(2, results.Count);
-        Assert.Equal("beta", results[0].Record.HotelId);
-        Assert.True(results[0].Score >= results[1].Score);
+        var first = results[0];
+        var second = results[1];
+        Assert.NotNull(first.Record);
+        var firstRecord = first.Record!;
+        Assert.NotNull(firstRecord.HotelId);
+        var firstHotelId = firstRecord.HotelId!;
+        Assert.Equal("beta", firstHotelId);
+        Assert.True(first.Score >= second.Score);
     }
 
     [Fact]
@@ -377,6 +383,529 @@ public sealed class LiteDbVectorStoreTests
 
         Assert.Contains("hotels", collectionNames);
         Assert.Contains("generated_hotels", collectionNames);
+    }
+
+    [Fact]
+    public async Task FilterSupportsStringMembershipAndNestedGroupsAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions { DisposeDatabase = false });
+
+        var collection = store.GetCollection<string, TaggedHotel>("tagged_hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        await collection.UpsertAsync(new[]
+        {
+            new TaggedHotel
+            {
+                HotelId = "alpha",
+                City = "Seattle",
+                Rating = 5,
+                Tags = new[] { "spa", "downtown" },
+                Description = "Coastline Inn",
+                DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f, 0f })
+            },
+            new TaggedHotel
+            {
+                HotelId = "beta",
+                City = "Portland",
+                Rating = 4,
+                Tags = new[] { "business" },
+                Description = "City Center Hotel",
+                DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 1f, 0f })
+            },
+            new TaggedHotel
+            {
+                HotelId = "gamma",
+                City = "Seattle",
+                Rating = 3,
+                Tags = new[] { "historic" },
+                Description = "Harbor Inn",
+                DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 0f, 1f })
+            }
+        });
+
+        var results = new List<TaggedHotel>();
+        var allowedCities = new[] { "Seattle", "Portland" };
+        await foreach (var record in collection.GetAsync(
+            h => (h.Tags.Contains("spa") || h.City!.StartsWith("Sea"))
+                && allowedCities.Contains(h.City!)
+                && h.Description!.EndsWith("Inn")
+                && h.Rating >= 4,
+            top: 5))
+        {
+            results.Add(record);
+        }
+
+        var result = Assert.Single(results);
+        Assert.NotNull(result.HotelId);
+        var hotelId = result.HotelId!;
+        Assert.Equal("alpha", hotelId);
+    }
+
+    [Fact]
+    public async Task BatchUpsertRollsBackOnFailureAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions { DisposeDatabase = false });
+
+        var collection = store.GetCollection<string, TestHotel>("hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        var rawCollection = database.GetCollection<BsonDocument>("hotels");
+        rawCollection.EnsureIndex(nameof(TestHotel.HotelName), unique: true);
+
+        var records = new[]
+        {
+            new TestHotel
+            {
+                HotelId = "alpha",
+                HotelName = "Duplicate",
+                Rating = 4,
+                City = "Seattle",
+                DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f, 0f })
+            },
+            new TestHotel
+            {
+                HotelId = "beta",
+                HotelName = "Duplicate",
+                Rating = 5,
+                City = "Portland",
+                DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 1f, 0f })
+            }
+        };
+
+        await Assert.ThrowsAsync<LiteException>(() => collection.UpsertAsync(records));
+
+        Assert.Empty(rawCollection.FindAll());
+    }
+
+    [Fact]
+    public async Task ThrowsWhenVectorDimensionsMismatchAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions { DisposeDatabase = false });
+
+        var collection = store.GetCollection<string, TestHotel>("hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        var invalid = new TestHotel
+        {
+            HotelId = "alpha",
+            HotelName = "Alpha",
+            City = "Seattle",
+            Rating = 4,
+            DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f })
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => collection.UpsertAsync(invalid));
+        Assert.Contains("expects 3 dimensions", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PropertyAndCollectionMetricsTakePrecedenceOverStoreDefaultsAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+
+        var storeOptions = new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            DistanceMetric = LiteDbDistanceMetric.Cosine
+        };
+
+        var collectionOptions = new LiteDbCollectionOptions
+        {
+            DistanceMetric = LiteDbDistanceMetric.Euclidean
+        };
+
+        using var collection = new LiteDbCollection<string, MultiVectorHotel>(
+            database,
+            "multi_hotels",
+            storeOptions,
+            collectionOptions,
+            opts => new LiteDbModelBuilder().Build(typeof(MultiVectorHotel), opts.Definition, opts.EmbeddingGenerator),
+            connectionIdentifier: "test");
+
+        await collection.EnsureCollectionExistsAsync();
+
+        await collection.UpsertAsync(new[]
+        {
+            new MultiVectorHotel
+            {
+                HotelId = "alpha",
+                AmenitiesEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f }),
+                LocationEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 10f })
+            },
+            new MultiVectorHotel
+            {
+                HotelId = "beta",
+                AmenitiesEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 1f }),
+                LocationEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 2f })
+            }
+        });
+
+        var amenityResults = new List<VectorSearchResult<MultiVectorHotel>>();
+        var amenityOptions = new VectorSearchOptions<MultiVectorHotel>
+        {
+            VectorProperty = h => h.AmenitiesEmbedding
+        };
+
+        await foreach (var result in collection.SearchAsync(new ReadOnlyMemory<float>(new[] { 0f, 1f }), top: 1, amenityOptions))
+        {
+            amenityResults.Add(result);
+        }
+
+        Assert.Single(amenityResults);
+        Assert.Equal("beta", amenityResults[0].Record.HotelId);
+
+        var locationResults = new List<VectorSearchResult<MultiVectorHotel>>();
+        var locationOptions = new VectorSearchOptions<MultiVectorHotel>
+        {
+            VectorProperty = h => h.LocationEmbedding
+        };
+
+        await foreach (var result in collection.SearchAsync(new ReadOnlyMemory<float>(new[] { 0f, 0f }), top: 1, locationOptions))
+        {
+            locationResults.Add(result);
+        }
+
+        Assert.Single(locationResults);
+        Assert.Equal("beta", locationResults[0].Record.HotelId);
+    }
+
+    [Fact]
+    public async Task PropertySpecificEmbeddingGeneratorOverridesDefaultsAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+
+        var defaultGenerator = new TrackingStringEmbeddingGenerator(value => new[] { 9f, 9f, 9f });
+        var overrideGenerator = new TrackingStringEmbeddingGenerator(ParseVector);
+
+        var storeOptions = new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            EmbeddingGenerator = defaultGenerator
+        };
+
+        using var store = new LiteDbVectorStore(database, storeOptions);
+
+        var definition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            {
+                new VectorStoreKeyProperty(nameof(OverrideHotel.HotelId), typeof(string)),
+                new VectorStoreVectorProperty<string>(nameof(OverrideHotel.Overview), 3)
+                {
+                    EmbeddingGenerator = overrideGenerator
+                },
+                new VectorStoreVectorProperty<string>(nameof(OverrideHotel.Amenities), 3)
+            }
+        };
+
+        var collection = store.GetCollection<string, OverrideHotel>("override_hotels", definition);
+        await collection.EnsureCollectionExistsAsync();
+
+        var record = new OverrideHotel
+        {
+            HotelId = "alpha",
+            Overview = "1,0,0",
+            Amenities = "0,1,0"
+        };
+
+        await collection.UpsertAsync(record);
+
+        var raw = database.GetCollection("override_hotels").FindById("alpha");
+        Assert.NotNull(raw);
+        Assert.Equal(new[] { 1f, 0f, 0f }, ((BsonVector)raw![nameof(OverrideHotel.Overview)]).Values);
+        Assert.Equal(new[] { 9f, 9f, 9f }, ((BsonVector)raw![nameof(OverrideHotel.Amenities)]).Values);
+
+        Assert.Equal(1, overrideGenerator.BatchCalls);
+        Assert.Single(overrideGenerator.BatchInputs);
+        Assert.Equal("1,0,0", overrideGenerator.BatchInputs[0]);
+        Assert.Equal(1, defaultGenerator.BatchCalls);
+        Assert.Single(defaultGenerator.BatchInputs);
+        Assert.Equal("0,1,0", defaultGenerator.BatchInputs[0]);
+
+        var options = new VectorSearchOptions<OverrideHotel>
+        {
+            VectorProperty = h => h.Overview
+        };
+
+        var searchResults = new List<VectorSearchResult<OverrideHotel>>();
+        await foreach (var result in collection.SearchAsync("1,0,0", top: 1, options))
+        {
+            searchResults.Add(result);
+        }
+
+        Assert.Single(searchResults);
+        Assert.Equal("alpha", searchResults[0].Record.HotelId);
+    }
+
+    [Fact]
+    public async Task CancellationStopsEmbeddingGenerationOnUpsertAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var generator = new CancellableEmbeddingGenerator();
+
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            EmbeddingGenerator = generator
+        });
+
+        var collection = store.GetCollection<string, GeneratedHotel>("generated_hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => collection.UpsertAsync(new GeneratedHotel
+        {
+            HotelId = "alpha",
+            Description = "1,0,0"
+        }, cts.Token));
+
+        Assert.Null(database.GetCollection("generated_hotels").FindById("alpha"));
+    }
+
+    [Fact]
+    public async Task CancellationStopsEmbeddingGenerationOnSearchAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var generator = new CancellableEmbeddingGenerator();
+
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            EmbeddingGenerator = generator
+        });
+
+        var collection = store.GetCollection<string, GeneratedHotel>("generated_hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        await collection.UpsertAsync(new GeneratedHotel
+        {
+            HotelId = "alpha",
+            Description = "1,0,0"
+        });
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in collection.SearchAsync("1,0,0", top: 1, cancellationToken: cts.Token))
+            {
+            }
+        });
+    }
+
+    [Fact]
+    public void AutoCreateVectorIndexesAliasKeepsOptionsInSync()
+    {
+        var options = new LiteDbVectorStoreOptions
+        {
+            AutoCreateVectorIndexes = false
+        };
+
+        Assert.False(options.AutoEnsureVectorIndex);
+
+        options.AutoEnsureVectorIndex = true;
+        Assert.True(options.AutoCreateVectorIndexes);
+
+        options.AutoCreateVectorIndexes = false;
+        Assert.False(options.AutoEnsureVectorIndex);
+    }
+
+    [Fact]
+    public async Task DatabaseFactoryHasHighestPrecedenceAsync()
+    {
+        var providedStream = new MemoryStream();
+        using var providedDatabase = new LiteDatabase(providedStream);
+
+        LiteDatabase? factoryDatabase = null;
+        var options = new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            Database = providedDatabase,
+            DatabaseFactory = () =>
+            {
+                factoryDatabase = new LiteDatabase(new MemoryStream());
+                return factoryDatabase;
+            }
+        };
+
+        using (var store = new LiteDbVectorStore(options))
+        {
+            var collection = store.GetCollection<string, TestHotel>("hotels");
+            await collection.EnsureCollectionExistsAsync();
+            await collection.UpsertAsync(new TestHotel
+            {
+                HotelId = "alpha",
+                HotelName = "Alpha",
+                City = "Seattle",
+                Rating = 4,
+                DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f, 0f })
+            });
+        }
+
+        Assert.NotNull(factoryDatabase);
+        Assert.NotNull(factoryDatabase!.GetCollection("hotels").FindById("alpha"));
+        Assert.Null(providedDatabase.GetCollection("hotels").FindById("alpha"));
+    }
+
+    [Fact]
+    public async Task DatabaseInstanceOverridesConnectionStringAsync()
+    {
+        using var providedDatabase = new LiteDatabase(new MemoryStream());
+        var options = new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            Database = providedDatabase,
+            ConnectionString = "Filename=ignored.db"
+        };
+
+        using (var store = new LiteDbVectorStore("Filename=also-ignored.db", options))
+        {
+            var collection = store.GetCollection<string, TestHotel>("hotels");
+            await collection.EnsureCollectionExistsAsync();
+            await collection.UpsertAsync(new TestHotel
+            {
+                HotelId = "alpha",
+                HotelName = "Alpha",
+                City = "Seattle",
+                Rating = 4,
+                DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f, 0f })
+            });
+        }
+
+        Assert.NotNull(providedDatabase.GetCollection("hotels").FindById("alpha"));
+    }
+
+    private static float[] ParseVector(string value)
+        => value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(float.Parse)
+            .ToArray();
+
+    private sealed class TaggedHotel
+    {
+        [VectorStoreKey]
+        public string? HotelId { get; set; }
+
+        [VectorStoreData]
+        public string[] Tags { get; set; } = Array.Empty<string>();
+
+        [VectorStoreData]
+        public string? City { get; set; }
+
+        [VectorStoreData]
+        public int Rating { get; set; }
+
+        [VectorStoreData]
+        public string? Description { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public ReadOnlyMemory<float>? DescriptionEmbedding { get; set; }
+    }
+
+    private sealed class MultiVectorHotel
+    {
+        [VectorStoreKey]
+        public string? HotelId { get; set; }
+
+        [VectorStoreVector(Dimensions: 2, DistanceFunction = DistanceFunction.DotProductSimilarity)]
+        public ReadOnlyMemory<float>? AmenitiesEmbedding { get; set; }
+
+        [VectorStoreVector(Dimensions: 2)]
+        public ReadOnlyMemory<float>? LocationEmbedding { get; set; }
+    }
+
+    private sealed class OverrideHotel
+    {
+        [VectorStoreKey]
+        public string? HotelId { get; set; }
+
+        public string? Overview { get; set; }
+
+        public string? Amenities { get; set; }
+    }
+
+    private sealed class TrackingStringEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        private readonly Func<string, float[]> _projection;
+
+        internal TrackingStringEmbeddingGenerator(Func<string, float[]> projection)
+        {
+            this._projection = projection;
+        }
+
+        public int BatchCalls { get; private set; }
+
+        public int SingleCalls { get; private set; }
+
+        public List<string> BatchInputs { get; } = new();
+
+        public List<string> SingleInputs { get; } = new();
+
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            this.BatchCalls++;
+
+            var embeddings = new GeneratedEmbeddings<Embedding<float>>();
+            foreach (var value in values)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                this.BatchInputs.Add(value);
+                embeddings.Add(new Embedding<float>(this._projection(value)));
+            }
+
+            return Task.FromResult(embeddings);
+        }
+
+        public Task<Embedding<float>> GenerateAsync(string value, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            this.SingleCalls++;
+            this.SingleInputs.Add(value);
+            return Task.FromResult(new Embedding<float>(this._projection(value)));
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class CancellableEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var embeddings = new GeneratedEmbeddings<Embedding<float>>();
+            foreach (var value in values)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                embeddings.Add(new Embedding<float>(ParseVector(value)));
+            }
+
+            return Task.FromResult(embeddings);
+        }
+
+        public Task<Embedding<float>> GenerateAsync(string value, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new Embedding<float>(ParseVector(value)));
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => null;
+
+        public void Dispose()
+        {
+        }
     }
 
     private sealed class TestHotel


### PR DESCRIPTION
## Summary
- Expand the LiteDB filter translator to handle string operators, captured constants, and collection membership with server-side predicates.
- Allow LiteDB vector store options to accept connection strings alongside injected databases and document the updated filtering behavior.
- Add an advanced LiteDB sample plus focused translator and vector store tests exercising the new operators.

## Testing
- DOTNET_ROLL_FORWARD=LatestMajor dotnet test dotnet/test/VectorData/LiteDb.UnitTests/LiteDb.UnitTests.csproj
- DOTNET_ROLL_FORWARD=LatestMajor dotnet test dotnet/samples/GettingStartedWithVectorStores/GettingStartedWithVectorStores.csproj --filter Step5_LiteDb_AdvancedScenario

------
https://chatgpt.com/codex/tasks/task_e_68e5713f65b48326b6d82837216fc30c