### PR TITLE
Fix LiteDB filter translation and add coverage

### DIFF
--- a/dotnet/samples/GettingStartedWithVectorStores/GettingStartedWithVectorStores.csproj
+++ b/dotnet/samples/GettingStartedWithVectorStores/GettingStartedWithVectorStores.csproj
@@ -12,6 +12,7 @@
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="LiteDB" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xRetry" />
     <PackageReference Include="xunit" />
@@ -43,6 +44,7 @@
     <ProjectReference Include="..\..\src\VectorData\AzureAISearch\AzureAISearch.csproj" />
     <ProjectReference Include="..\..\src\VectorData\InMemory\InMemory.csproj" />
     <ProjectReference Include="..\..\src\VectorData\Qdrant\Qdrant.csproj" />
+    <ProjectReference Include="..\..\src\VectorData\LiteDb\LiteDb.csproj" />
     <ProjectReference Include="..\..\src\VectorData\Redis\Redis.csproj" />
     <ProjectReference Include="..\..\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\SemanticKernel.Core\SemanticKernel.Core.csproj" />

--- a/dotnet/samples/GettingStartedWithVectorStores/README.md
+++ b/dotnet/samples/GettingStartedWithVectorStores/README.md
@@ -4,6 +4,8 @@ This project contains a step by step guide to get started using Vector Stores wi
 
 The examples can be run as integration tests but their code can also be copied to stand-alone programs.
 
+- `Step5_LiteDb_Advanced` shows how to use the LiteDB connector with transactional batch upserts, per-property embedding generators, and filtered vector searches.
+
 ## Configuring Secrets
 
 Most of the examples will require secrets and credentials, to access OpenAI, Azure OpenAI,

--- a/dotnet/samples/GettingStartedWithVectorStores/Step5_LiteDb_Advanced.cs
+++ b/dotnet/samples/GettingStartedWithVectorStores/Step5_LiteDb_Advanced.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteDB;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.LiteDb;
+
+namespace GettingStartedWithVectorStores;
+
+/// <summary>
+/// Demonstrates advanced LiteDB scenarios including transactional ingestion, per-property embedding generators, and filtered vector search.
+/// </summary>
+public sealed class Step5_LiteDb_Advanced(ITestOutputHelper output) : BaseTest(output)
+{
+    [Fact]
+    public async Task RunLiteDbAdvancedScenarioAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var storeOptions = new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            AutoCreateVectorIndexes = true,
+            EmbeddingGenerator = new CsvEmbeddingGenerator()
+        };
+
+        using var store = new LiteDbVectorStore(database, storeOptions);
+
+        var definition = new VectorStoreCollectionDefinition
+        {
+            EmbeddingGenerator = storeOptions.EmbeddingGenerator,
+            Properties =
+            {
+                new VectorStoreKeyProperty(nameof(HotelRecord.HotelId), typeof(string)),
+                new VectorStoreDataProperty(nameof(HotelRecord.City), typeof(string)) { IsIndexed = true },
+                new VectorStoreDataProperty(nameof(HotelRecord.Tags), typeof(string[])),
+                new VectorStoreDataProperty(nameof(HotelRecord.Rating), typeof(int)),
+                new VectorStoreVectorProperty<string>(nameof(HotelRecord.Description), 3),
+                new VectorStoreVectorProperty<string>(nameof(HotelRecord.Amenities), 3)
+                {
+                    DistanceFunction = DistanceFunction.DotProductSimilarity,
+                    EmbeddingGenerator = new KeywordEmbeddingGenerator()
+                }
+            }
+        };
+
+        var collection = store.GetCollection<string, HotelRecord>("hotels", definition);
+        await collection.EnsureCollectionExistsAsync();
+
+        var hotels = new[]
+        {
+            new HotelRecord { HotelId = "alpha", City = "Seattle", Rating = 5, Tags = new[] { "spa", "downtown" }, Description = "1,0,0", Amenities = "spa gym pool" },
+            new HotelRecord { HotelId = "beta", City = "Portland", Rating = 4, Tags = new[] { "spa", "budget" }, Description = "0,1,0", Amenities = "spa" },
+            new HotelRecord { HotelId = "gamma", City = "Chicago", Rating = 3, Tags = new[] { "business" }, Description = "0,0,1", Amenities = "conference" }
+        };
+
+        // Batched upsert operations are wrapped in a LiteDB transaction to ensure all-or-nothing writes.
+        await collection.UpsertAsync(hotels);
+
+        var searchOptions = new VectorSearchOptions<HotelRecord>
+        {
+            VectorProperty = h => h.Amenities,
+            Filter = h =>
+                ((h.Tags != null && h.Tags.Contains("spa")) || h.City!.StartsWith("Sea")) &&
+                new[] { "Seattle", "Portland" }.Contains(h.City!) &&
+                h.Rating >= 4
+        };
+
+        await foreach (var result in collection.SearchAsync("spa gym pool", top: 2, searchOptions))
+        {
+            this.Output.WriteLine($"{result.Record.HotelId}: {result.Score:F2}");
+        }
+    }
+
+    private sealed class HotelRecord
+    {
+        [VectorStoreKey]
+        public string? HotelId { get; set; }
+
+        [VectorStoreData]
+        public string? City { get; set; }
+
+        [VectorStoreData]
+        public string[]? Tags { get; set; }
+
+        [VectorStoreData]
+        public int Rating { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public string? Description { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public string? Amenities { get; set; }
+    }
+
+    private sealed class CsvEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            var embeddings = new GeneratedEmbeddings<Embedding<float>>();
+            foreach (var value in values)
+            {
+                embeddings.Add(Parse(value));
+            }
+
+            return Task.FromResult(embeddings);
+        }
+
+        public Task<Embedding<float>> GenerateAsync(string value, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(Parse(value));
+
+        private static Embedding<float> Parse(string value)
+        {
+            var numbers = value.Split(',', System.StringSplitOptions.RemoveEmptyEntries | System.StringSplitOptions.TrimEntries)
+                .Select(segment => float.TryParse(segment, out var parsed) ? parsed : 0f)
+                .ToArray();
+            return new Embedding<float>(numbers);
+        }
+
+        public object? GetService(System.Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class KeywordEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        private static readonly string[] Vocabulary = ["spa", "gym", "pool"];
+
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            var embeddings = new GeneratedEmbeddings<Embedding<float>>();
+            foreach (var value in values)
+            {
+                embeddings.Add(CreateEmbedding(value));
+            }
+
+            return Task.FromResult(embeddings);
+        }
+
+        public Task<Embedding<float>> GenerateAsync(string value, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(CreateEmbedding(value));
+
+        private static Embedding<float> CreateEmbedding(string value)
+        {
+            var tokens = value.Split(' ', System.StringSplitOptions.RemoveEmptyEntries | System.StringSplitOptions.TrimEntries);
+            var vector = Vocabulary.Select(v => tokens.Count(t => string.Equals(t, v, System.StringComparison.OrdinalIgnoreCase))).Select(count => (float)count).ToArray();
+            return new Embedding<float>(vector);
+        }
+
+        public object? GetService(System.Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/dotnet/src/VectorData/LiteDb/LiteDbCollection.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbCollection.cs
@@ -89,7 +89,8 @@ public class LiteDbCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
     /// <inheritdoc />
     public override Task EnsureCollectionExistsAsync(CancellationToken cancellationToken = default)
     {
-        if (this._storeOptions.AutoEnsureVectorIndex && this._vectorProperties.Count > 0)
+        var autoEnsure = this._storeOptions.AutoCreateVectorIndexes ?? this._storeOptions.AutoEnsureVectorIndex;
+        if (autoEnsure && this._vectorProperties.Count > 0)
         {
             foreach (var vectorProperty in this._vectorProperties)
             {
@@ -174,7 +175,32 @@ public class LiteDbCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
             documents.Add(this._mapper.MapToDocument(materialized[i], generatedVectors, i));
         }
 
-        this._collection.Upsert(documents);
+        var useTransaction = materialized.Count > 1;
+        var transactionStarted = false;
+
+        try
+        {
+            if (useTransaction)
+            {
+                transactionStarted = this._database.BeginTrans();
+            }
+
+            this._collection.Upsert(documents);
+
+            if (transactionStarted)
+            {
+                this._database.Commit();
+            }
+        }
+        catch
+        {
+            if (transactionStarted)
+            {
+                this._database.Rollback();
+            }
+
+            throw;
+        }
     }
 
     /// <inheritdoc />
@@ -249,24 +275,42 @@ public class LiteDbCollection<TKey, TRecord> : VectorStoreCollection<TKey, TReco
         var take = top + options.Skip;
         var results = query.TopKNear($"$.{vectorProperty.StorageName}", vectorArray, take).ToEnumerable();
 
-        var index = 0;
+        var buffer = new List<VectorSearchResult<TRecord>>();
 
         foreach (var document in results)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (index++ < options.Skip)
-            {
-                continue;
-            }
-            var record = this._mapper.MapToRecord(document, options.IncludeVectors);
 
             if (!document.TryGetValue(vectorProperty.StorageName, out var value) || value is not BsonVector candidate)
             {
                 continue;
             }
 
+            var record = this._mapper.MapToRecord(document, options.IncludeVectors);
             var score = LiteDbVectorMath.Compare(vectorArray, candidate.Values, metric);
-            yield return new VectorSearchResult<TRecord>(record, score);
+            buffer.Add(new VectorSearchResult<TRecord>(record, score));
+        }
+
+        var ordered = LiteDbVectorMath.ShouldSortDescending(metric)
+            ? buffer.OrderByDescending(result => result.Score)
+            : buffer.OrderBy(result => result.Score);
+
+        var skipped = 0;
+        var yielded = 0;
+
+        foreach (var result in ordered)
+        {
+            if (skipped < options.Skip)
+            {
+                skipped++;
+                continue;
+            }
+
+            yield return result;
+            if (++yielded >= top)
+            {
+                yield break;
+            }
         }
     }
 

--- a/dotnet/src/VectorData/LiteDb/LiteDbFilterTranslator.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbFilterTranslator.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Linq.Expressions;
 using LiteDB;
 using Microsoft.Extensions.VectorData.ProviderServices;
@@ -37,6 +38,9 @@ internal sealed class LiteDbFilterTranslator
             BinaryExpression binary when IsComparison(binary.NodeType) => this.TranslateComparison(binary),
             BinaryExpression binary when binary.NodeType is ExpressionType.AndAlso or ExpressionType.OrElse
                 => this.TranslateLogical(binary),
+            MethodCallExpression method => this.TranslateMethodCall(method),
+            QueryParameterExpression { Value: var boolValue } parameter when parameter.Type == typeof(bool)
+                => boolValue is true ? "true" : "false",
             UnaryExpression { NodeType: ExpressionType.Not } not => $"NOT ({this.TranslateNode(not.Operand)})",
             UnaryExpression { NodeType: ExpressionType.Convert } convert => this.TranslateNode(convert.Operand),
             Expression expr when expr.Type == typeof(bool) && this.TryBindProperty(expr, out var property)
@@ -46,17 +50,133 @@ internal sealed class LiteDbFilterTranslator
 
     private string TranslateComparison(BinaryExpression binary)
     {
-        if (this.TryBindProperty(binary.Left, out var property) && binary.Right is ConstantExpression { Value: var constant })
+        if (this.TryBindProperty(binary.Left, out var property) && this.TryExtractValue(binary.Right, out var constant))
         {
             return this.GenerateComparison(property, constant, binary.NodeType);
         }
 
-        if (this.TryBindProperty(binary.Right, out property) && binary.Left is ConstantExpression { Value: var leftConstant })
+        if (this.TryBindProperty(binary.Right, out property) && this.TryExtractValue(binary.Left, out var leftConstant))
         {
             return this.GenerateComparison(property, leftConstant, binary.NodeType);
         }
 
         throw new NotSupportedException("LiteDB filter translation expects member-to-constant comparisons.");
+    }
+
+    private string TranslateMethodCall(MethodCallExpression method)
+    {
+        if (this.TryBindProperty(method, out var property))
+        {
+            return this.GenerateComparison(property, true, ExpressionType.Equal);
+        }
+
+        if (method.Method.DeclaringType == typeof(string) && method.Object is { } instance && this.TryBindProperty(instance, out property))
+        {
+            return method.Method.Name switch
+            {
+                nameof(string.Contains) => this.TranslateStringPattern(property, method.Arguments, PatternKind.Contains, method.Method.Name),
+                nameof(string.StartsWith) => this.TranslateStringPattern(property, method.Arguments, PatternKind.StartsWith, method.Method.Name),
+                nameof(string.EndsWith) => this.TranslateStringPattern(property, method.Arguments, PatternKind.EndsWith, method.Method.Name),
+                _ => throw new NotSupportedException($"String method '{method.Method.Name}' is not supported in LiteDB filters.")
+            };
+        }
+
+        if (IsEnumerableContains(method, out var source, out var item))
+        {
+            return this.TranslateContains(source, item);
+        }
+
+        throw new NotSupportedException($"Unsupported method call '{method.Method.DeclaringType?.Name}.{method.Method.Name}'.");
+    }
+
+    private string TranslateContains(Expression source, Expression item)
+    {
+        if (!this.TryBindProperty(item, out var property))
+        {
+            if (this.TryBindProperty(source, out property) && this.TryExtractValue(item, out var element))
+            {
+                var placeholder = this.AddParameter(CreateParameter(element));
+                return $"({placeholder} IN $.{property.StorageName})";
+            }
+
+            throw new NotSupportedException("LiteDB filters support set membership between collection properties and constant values only.");
+        }
+
+        var values = this.MaterializeValues(source);
+        var placeholderArray = this.AddParameter(values);
+        return $"($.{property.StorageName} IN {placeholderArray})";
+    }
+
+    private string TranslateStringPattern(PropertyModel property, IReadOnlyList<Expression> arguments, PatternKind kind, string methodName)
+    {
+        if (arguments.Count is < 1 or > 2)
+        {
+            throw new NotSupportedException($"String method '{methodName}' must specify a single comparison value.");
+        }
+
+        if (!this.TryExtractValue(arguments[0], out var argumentValue))
+        {
+            throw new NotSupportedException($"String method '{methodName}' requires a constant comparison value.");
+        }
+
+        if (argumentValue is not string text)
+        {
+            throw new InvalidCastException($"String method '{methodName}' requires a string constant, but '{argumentValue?.GetType().Name ?? "null"}' was provided.");
+        }
+
+        if (arguments.Count == 2)
+        {
+            if (!this.TryExtractValue(arguments[1], out var comparisonValue) || comparisonValue is not StringComparison stringComparison)
+            {
+                throw new NotSupportedException($"String method '{methodName}' only supports constant {nameof(StringComparison)} values.");
+            }
+
+            if (stringComparison != StringComparison.Ordinal)
+            {
+                throw new NotSupportedException($"String method '{methodName}' only supports {nameof(StringComparison.Ordinal)}.");
+            }
+        }
+
+        var pattern = kind switch
+        {
+            PatternKind.Contains => $"%{EscapeLike(text)}%",
+            PatternKind.StartsWith => $"{EscapeLike(text)}%",
+            PatternKind.EndsWith => $"%{EscapeLike(text)}",
+            _ => throw new NotSupportedException($"Pattern '{kind}' is not supported.")
+        };
+
+        var placeholder = this.AddParameter(new BsonValue(pattern));
+        return $"($.{property.StorageName} LIKE {placeholder})";
+    }
+
+    private BsonArray MaterializeValues(Expression source)
+    {
+        if (!this.TryExtractValue(source, out var value))
+        {
+            throw new NotSupportedException("Set membership clauses must compare against a constant or captured collection.");
+        }
+
+        if (value is string)
+        {
+            throw new NotSupportedException("Set membership cannot compare against a string. Provide a collection of values instead.");
+        }
+
+        if (value is not System.Collections.IEnumerable enumerable)
+        {
+            throw new NotSupportedException("Set membership clauses require a collection value.");
+        }
+
+        var array = new BsonArray();
+        foreach (var element in enumerable)
+        {
+            array.Add(element switch
+            {
+                BsonValue bsonElement => bsonElement,
+                _ => new BsonValue(element)
+            });
+        }
+
+        return array;
     }
 
     private string TranslateLogical(BinaryExpression binary)
@@ -74,13 +194,13 @@ internal sealed class LiteDbFilterTranslator
         {
             return nodeType switch
             {
-                ExpressionType.Equal => $"({field} IS NULL)",
-                ExpressionType.NotEqual => $"({field} IS NOT NULL)",
+                ExpressionType.Equal => $"({field} = null)",
+                ExpressionType.NotEqual => $"({field} != null)",
                 _ => throw new NotSupportedException("Null comparisons are only supported for equality checks.")
             };
         }
 
-        var placeholder = this.AddParameter(new BsonValue(value));
+        var placeholder = this.AddParameter(CreateParameter(value));
         var op = nodeType switch
         {
             ExpressionType.Equal => "=",
@@ -100,6 +220,62 @@ internal sealed class LiteDbFilterTranslator
         var index = this._parameters.Count;
         this._parameters.Add(value);
         return $"@{index}";
+    }
+
+    private static BsonValue CreateParameter(object? value)
+    {
+        if (value is BsonValue bson)
+        {
+            return bson;
+        }
+
+        if (value is System.Collections.IEnumerable enumerable && value is not string)
+        {
+            var array = new BsonArray();
+            foreach (var element in enumerable)
+            {
+                array.Add(element switch
+                {
+                    BsonValue bsonElement => bsonElement,
+                    _ => new BsonValue(element)
+                });
+            }
+
+            return array;
+        }
+
+        return new BsonValue(value);
+    }
+
+    private bool TryExtractValue(Expression expression, out object? value)
+    {
+        switch (expression)
+        {
+            case ConstantExpression { Value: var constant }:
+                value = constant;
+                return true;
+            case QueryParameterExpression { Value: var parameter }:
+                value = parameter;
+                return true;
+            case NewArrayExpression { NodeType: ExpressionType.NewArrayInit } newArray:
+                var elementType = newArray.Type.GetElementType() ?? typeof(object);
+                var array = Array.CreateInstance(elementType, newArray.Expressions.Count);
+                for (var i = 0; i < newArray.Expressions.Count; i++)
+                {
+                    if (!this.TryExtractValue(newArray.Expressions[i], out var elementValue))
+                    {
+                        throw new NotSupportedException("Set membership clauses must use constant values.");
+                    }
+
+                    array.SetValue(elementValue, i);
+                }
+
+                value = array;
+                return true;
+            default:
+                value = null;
+                return false;
+        }
     }
 
     private static bool IsComparison(ExpressionType type)
@@ -152,5 +328,46 @@ internal sealed class LiteDbFilterTranslator
         }
 
         return true;
+    }
+
+    private static bool IsEnumerableContains(MethodCallExpression methodCall, out Expression source, out Expression item)
+    {
+        if (methodCall.Method.Name != nameof(Enumerable.Contains))
+        {
+            source = null!;
+            item = null!;
+            return false;
+        }
+
+        if (methodCall.Method.DeclaringType == typeof(Enumerable) && methodCall.Arguments.Count == 2)
+        {
+            source = methodCall.Arguments[0];
+            item = methodCall.Arguments[1];
+            return true;
+        }
+
+        if (methodCall.Object is not null && methodCall.Arguments.Count == 1)
+        {
+            source = methodCall.Object;
+            item = methodCall.Arguments[0];
+            return true;
+        }
+
+        source = null!;
+        item = null!;
+        return false;
+    }
+
+    private static string EscapeLike(string text)
+        => text
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal);
+
+    private enum PatternKind
+    {
+        Contains,
+        StartsWith,
+        EndsWith
     }
 }

--- a/dotnet/src/VectorData/LiteDb/LiteDbMapper.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbMapper.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.VectorData.ProviderServices;
 using LiteDB;
@@ -32,7 +34,7 @@ internal sealed class LiteDbMapper<TRecord>(CollectionModel model)
                 continue;
             }
 
-            document[property.StorageName] = new BsonValue(value);
+            document[property.StorageName] = CreateBsonValue(value);
         }
 
         foreach (var property in this._model.VectorProperties)
@@ -50,6 +52,11 @@ internal sealed class LiteDbMapper<TRecord>(CollectionModel model)
 
             if (vector is not null)
             {
+                if (property.Dimensions > 0 && vector.Length != property.Dimensions)
+                {
+                    throw new InvalidOperationException($"Vector property '{property.ModelName}' expects {property.Dimensions} dimensions but received {vector.Length}.");
+                }
+
                 document[property.StorageName] = new BsonVector(vector);
             }
         }
@@ -124,6 +131,44 @@ internal sealed class LiteDbMapper<TRecord>(CollectionModel model)
         }
     }
 
+    private static BsonValue CreateBsonValue(object value)
+    {
+        switch (value)
+        {
+            case BsonValue bson:
+                return bson;
+            case byte[] bytes:
+                return new BsonValue(bytes);
+        }
+
+        if (value is IDictionary dictionary)
+        {
+            var document = new BsonDocument();
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                if (entry.Key is string key)
+                {
+                    document[key] = entry.Value is null ? BsonValue.Null : CreateBsonValue(entry.Value);
+                }
+            }
+
+            return document;
+        }
+
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            var array = new BsonArray();
+            foreach (var item in enumerable)
+            {
+                array.Add(item is null ? BsonValue.Null : CreateBsonValue(item));
+            }
+
+            return array;
+        }
+
+        return new BsonValue(value);
+    }
+
     private static object? ConvertValue(BsonValue value, Type targetType)
     {
         var underlyingType = Nullable.GetUnderlyingType(targetType) ?? targetType;
@@ -181,6 +226,16 @@ internal sealed class LiteDbMapper<TRecord>(CollectionModel model)
             }
 
             return dictionary;
+        }
+
+        if (underlyingType.IsArray && underlyingType.GetElementType() == typeof(string) && value.RawValue is IEnumerable<BsonValue> bsonArray)
+        {
+            return bsonArray.Select(v => v.AsString).ToArray();
+        }
+
+        if (underlyingType == typeof(List<string>) && value.RawValue is IEnumerable<BsonValue> bsonList)
+        {
+            return bsonList.Select(v => v.AsString).ToList();
         }
 
         return value.RawValue;

--- a/dotnet/src/VectorData/LiteDb/LiteDbVectorStoreOptions.cs
+++ b/dotnet/src/VectorData/LiteDb/LiteDbVectorStoreOptions.cs
@@ -12,6 +12,8 @@ namespace Microsoft.SemanticKernel.Connectors.LiteDb;
 public sealed class LiteDbVectorStoreOptions
 {
     internal static readonly LiteDbVectorStoreOptions Default = new();
+    private bool _autoEnsureVectorIndex = true;
+    private bool? _autoCreateVectorIndexes;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LiteDbVectorStoreOptions"/> class.
@@ -32,7 +34,8 @@ public sealed class LiteDbVectorStoreOptions
         this.DatabaseFactory = source.DatabaseFactory;
         this.DisposeDatabase = source.DisposeDatabase;
         this.DistanceMetric = source.DistanceMetric;
-        this.AutoEnsureVectorIndex = source.AutoEnsureVectorIndex;
+        this._autoEnsureVectorIndex = source._autoEnsureVectorIndex;
+        this._autoCreateVectorIndexes = source._autoCreateVectorIndexes;
         this.EmbeddingGenerator = source.EmbeddingGenerator;
         this.CollectionNamePrefix = source.CollectionNamePrefix;
     }
@@ -74,7 +77,34 @@ public sealed class LiteDbVectorStoreOptions
     /// <summary>
     /// Gets or sets a value indicating whether collections created through this store automatically ensure their vector index.
     /// </summary>
-    public bool AutoEnsureVectorIndex { get; set; } = true;
+    public bool AutoEnsureVectorIndex
+    {
+        get => this._autoEnsureVectorIndex;
+        set
+        {
+            this._autoEnsureVectorIndex = value;
+            this._autoCreateVectorIndexes = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether collections created through this store automatically ensure their vector index.
+    /// </summary>
+    /// <remarks>
+    /// This is an alias for <see cref="AutoEnsureVectorIndex"/>. When specified, the alias takes precedence.
+    /// </remarks>
+    public bool? AutoCreateVectorIndexes
+    {
+        get => this._autoCreateVectorIndexes;
+        set
+        {
+            this._autoCreateVectorIndexes = value;
+            if (value.HasValue)
+            {
+                this._autoEnsureVectorIndex = value.Value;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets or sets the default embedding generator to use when generating embeddings for vector properties.

--- a/dotnet/src/VectorData/LiteDb/README.md
+++ b/dotnet/src/VectorData/LiteDb/README.md
@@ -34,6 +34,8 @@ using var store = new LiteDbVectorStore(options);
 
 Collections created through this store are materialized as `sk_*` tables, while APIs such as `CollectionExistsAsync` and `ListCollectionNamesAsync` use the logical names you pass to `GetCollection`.
 
+`LiteDbVectorStoreOptions` honor the precedence `DatabaseFactory` → `Database` → `ConnectionString`. When `AutoCreateVectorIndexes` (or the legacy `AutoEnsureVectorIndex`) is set to `false`, collections skip index provisioning and you can manage indexes manually.
+
 ## Defining a collection
 
 Collections map strongly-typed record models to LiteDB BSON documents. Use the Semantic Kernel attributes to annotate key, data, and vector fields:
@@ -57,6 +59,23 @@ await collection.EnsureCollectionExistsAsync();
 
 The connector automatically provisions HNSW vector indexes when `EnsureCollectionExistsAsync` is called and a vector property is present. Distance metrics default to cosine similarity but can be overridden through attributes or `LiteDbCollectionOptions`.
 
+### Filter translation
+
+LiteDB evaluates filters server-side. The table below shows how common Semantic Kernel expressions translate into LiteDB predicates:
+
+| Semantic Kernel expression | LiteDB predicate |
+| --------------------------- | ---------------- |
+| `hotel => hotel.Rating >= 4` | `($.Rating >= @0)` |
+| `hotel => hotel.City.StartsWith("Sea")` | `($.City LIKE @0)` with `@0 = "Sea%"` |
+| `hotel => hotel.City.EndsWith("town")` | `($.City LIKE @0)` with `@0 = "%town"` |
+| `hotel => hotel.City.Contains("port")` | `($.City LIKE @0)` with `@0 = "%port%"` |
+| `hotel => hotel.Tags.Contains("spa")` | `(@0 IN $.Tags)` |
+| `allowedCities.Contains(hotel.City!)` | `($.City IN @0)` |
+| `hotel => hotel.City == null` | `($.City = null)` |
+| `hotel => hotel.City != null` | `($.City != null)` |
+
+Captured variables are parameterized (`@0`, `@1`, …) so repeated values are not interpolated into the query text.
+
 ## Generating embeddings on the fly
 
 When a record's vector property is a non-vector type (for example `string` or `DataContent`), configure an `IEmbeddingGenerator` so that LiteDB receives vectors during `UpsertAsync` and vector search:
@@ -71,7 +90,11 @@ var store = new LiteDbVectorStore("Filename=sk.db", options);
 var collection = store.GetCollection<string, Article>("articles");
 ```
 
-The store-level generator is inherited by collections, but you can override it per collection via `LiteDbCollectionOptions` or per property through a `VectorStoreCollectionDefinition`.
+The store-level generator is inherited by collections, and you can override it per property through a `VectorStoreCollectionDefinition`. This allows different embedding generators to service different vector fields within the same record.
+
+## Transactions and batch ingestion
+
+`UpsertAsync(IEnumerable<TRecord>)` wraps batched writes in a LiteDB transaction. Either every document is inserted or updated, or none of them are. Single-record upserts remain non-transactional for minimum overhead.
 
 ## Dependency injection
 
@@ -112,8 +135,13 @@ var definition = new VectorStoreCollectionDefinition
 var dynamicCollection = store.GetDynamicCollection("snippets", definition);
 ```
 
+## Performance notes
+
+- Vector index creation happens on demand during `EnsureCollectionExistsAsync`. For large collections it is faster to ingest in batches and call `EnsureCollectionExistsAsync` once.
+- Server-side filters are most effective when the predicate is selective (for example, indexed equality or range comparisons) before vector search runs.
+- LiteDB's vector APIs are synchronous; high-throughput scenarios should run on background threads or batch operations.
+
 ## Limitations
 
-- LiteDB's vector APIs are synchronous; high-throughput scenarios should run on background threads or batch operations.
 - LiteDB databases are single-process; avoid opening the same file from multiple processes simultaneously. (although supported)
 - `IncludeVectors` cannot be enabled on retrieval operations when embedding generation is configured, matching the behavior of other Semantic Kernel connectors.

--- a/dotnet/test/VectorData/LiteDb.UnitTests/LiteDbVectorStoreTests.cs
+++ b/dotnet/test/VectorData/LiteDb.UnitTests/LiteDbVectorStoreTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using LiteDB;
@@ -135,6 +136,108 @@ public sealed class LiteDbVectorStoreTests
     }
 
     [Fact]
+    public async Task PropertySpecificEmbeddingGeneratorOverridesDefaultsAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var defaultGenerator = new ZeroEmbeddingGenerator();
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            EmbeddingGenerator = defaultGenerator
+        });
+
+        var definition = new VectorStoreCollectionDefinition
+        {
+            EmbeddingGenerator = defaultGenerator,
+            Properties =
+            {
+                new VectorStoreKeyProperty(nameof(CompositeGeneratedHotel.HotelId), typeof(string)),
+                new VectorStoreVectorProperty<string>(nameof(CompositeGeneratedHotel.Summary), 3)
+                {
+                    EmbeddingGenerator = new StringEmbeddingGenerator()
+                },
+                new VectorStoreVectorProperty<string>(nameof(CompositeGeneratedHotel.Details), 3)
+            }
+        };
+
+        var collection = store.GetCollection<string, CompositeGeneratedHotel>("composite_hotels", definition);
+        await collection.EnsureCollectionExistsAsync();
+
+        await collection.UpsertAsync(new CompositeGeneratedHotel
+        {
+            HotelId = "alpha",
+            Summary = "1,2,3",
+            Details = "ignored"
+        });
+
+        var document = database.GetCollection(collection.Name).FindById("alpha");
+
+        Assert.NotNull(document);
+        Assert.True(document.TryGetValue(nameof(CompositeGeneratedHotel.Summary), out var summaryValue));
+        Assert.IsType<BsonVector>(summaryValue);
+        Assert.Equal(new[] { 1f, 2f, 3f }, ((BsonVector)summaryValue).Values);
+        Assert.True(document.TryGetValue(nameof(CompositeGeneratedHotel.Details), out var detailsValue));
+        Assert.IsType<BsonVector>(detailsValue);
+        Assert.Equal(new[] { 0f, 0f, 0f }, ((BsonVector)detailsValue).Values);
+    }
+
+    [Fact]
+    public async Task UpsertAsyncHonorsCancellationDuringEmbeddingGeneration()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            EmbeddingGenerator = new BlockingEmbeddingGenerator()
+        });
+
+        var collection = store.GetCollection<string, GeneratedHotel>("generated_hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        var record = new GeneratedHotel { HotelId = "alpha", Description = "1,0,0" };
+        using var cts = new CancellationTokenSource();
+
+        var upsertTask = collection.UpsertAsync(record, cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => upsertTask);
+    }
+
+    [Fact]
+    public async Task SearchAsyncHonorsCancellationDuringEmbeddingGeneration()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+
+        using (var seedStore = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            EmbeddingGenerator = new StringEmbeddingGenerator()
+        }))
+        {
+            var seedCollection = seedStore.GetCollection<string, GeneratedHotel>("generated_hotels");
+            await seedCollection.EnsureCollectionExistsAsync();
+            await seedCollection.UpsertAsync(new GeneratedHotel { HotelId = "alpha", Description = "1,0,0" });
+        }
+
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            EmbeddingGenerator = new BlockingEmbeddingGenerator()
+        });
+
+        var collection = store.GetCollection<string, GeneratedHotel>("generated_hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        using var cts = new CancellationTokenSource();
+        await using var enumerator = collection.SearchAsync("1,0,0", top: 1, cancellationToken: cts.Token).GetAsyncEnumerator();
+
+        var moveTask = enumerator.MoveNextAsync().AsTask();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => moveTask);
+    }
+
+    [Fact]
     public async Task SearchHonorsDistanceMetricsAsync()
     {
         using var database = new LiteDatabase(new MemoryStream());
@@ -178,6 +281,112 @@ public sealed class LiteDbVectorStoreTests
     }
 
     [Fact]
+    public async Task VectorSearchHonorsMetricPrecedenceAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var storeOptions = new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            DistanceMetric = LiteDbDistanceMetric.DotProduct
+        };
+
+        using var store = new LiteDbVectorStore(storeOptions);
+
+        var collection = store.GetCollection<string, MultiMetricHotel>("multi_metric_hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        var optionsField = typeof(LiteDbCollection<string, MultiMetricHotel>).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic);
+        var collectionOptions = Assert.IsType<LiteDbCollectionOptions>(optionsField!.GetValue(collection));
+        collectionOptions.DistanceMetric = LiteDbDistanceMetric.Euclidean;
+
+        await collection.UpsertAsync(new[]
+        {
+            new MultiMetricHotel
+            {
+                HotelId = "dominant",
+                AmenitiesEmbedding = new ReadOnlyMemory<float>(new[] { 10f, 0f, 0f }),
+                LocationEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 10f, 0f })
+            },
+            new MultiMetricHotel
+            {
+                HotelId = "target",
+                AmenitiesEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f, 0f }),
+                LocationEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 1f, 0f })
+            }
+        });
+
+        var amenitiesResults = new List<VectorSearchResult<MultiMetricHotel>>();
+        await foreach (var result in collection.SearchAsync(new ReadOnlyMemory<float>(new[] { 1f, 0f, 0f }), top: 2, new VectorSearchOptions<MultiMetricHotel>
+        {
+            VectorProperty = h => h.AmenitiesEmbedding
+        }))
+        {
+            amenitiesResults.Add(result);
+        }
+
+        Assert.Equal("dominant", amenitiesResults[0].Record.HotelId);
+
+        var locationOptions = new VectorSearchOptions<MultiMetricHotel>
+        {
+            VectorProperty = h => h.LocationEmbedding
+        };
+
+        var locationResults = new List<VectorSearchResult<MultiMetricHotel>>();
+        await foreach (var result in collection.SearchAsync(new ReadOnlyMemory<float>(new[] { 0f, 1f, 0f }), top: 2, locationOptions))
+        {
+            locationResults.Add(result);
+        }
+
+        Assert.Equal("target", locationResults[0].Record.HotelId);
+
+        collectionOptions.DistanceMetric = null;
+
+        locationResults.Clear();
+        await foreach (var result in collection.SearchAsync(new ReadOnlyMemory<float>(new[] { 0f, 1f, 0f }), top: 2, locationOptions))
+        {
+            locationResults.Add(result);
+        }
+
+        Assert.Equal("dominant", locationResults[0].Record.HotelId);
+    }
+
+    [Fact]
+    public async Task FilterSupportsStringOperatorsAndMembershipAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions { DisposeDatabase = false });
+
+        var collection = store.GetCollection<string, TestHotel>("hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        var allowedCities = new[] { "Seattle", "Portland" };
+
+        await collection.UpsertAsync(new[]
+        {
+            new TestHotel { HotelId = "alpha", HotelName = "Alpha", Rating = 5, City = "Seattle", Tags = new[] { "spa", "downtown" }, DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f, 0f }) },
+            new TestHotel { HotelId = "beta", HotelName = "Beta", Rating = 4, City = "Portland", Tags = new[] { "spa", "budget" }, DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 1f, 0f }) },
+            new TestHotel { HotelId = "gamma", HotelName = "Gamma", Rating = 3, City = "Chicago", Tags = new[] { "business" }, DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 0f, 1f }) },
+            new TestHotel { HotelId = "delta", HotelName = "Delta", Rating = 4, City = "Spokane", Tags = new[] { "ski" }, DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 0.5f, 0.5f, 0f }) }
+        });
+
+        var filtered = new List<TestHotel>();
+        await foreach (var item in collection.GetAsync(
+            h => ((h.Tags != null && h.Tags.Contains("spa")) || h.City!.StartsWith("Sea"))
+                && allowedCities.Contains(h.City!)
+                && h.Rating >= 4,
+            top: 5))
+        {
+            filtered.Add(item);
+        }
+
+        Assert.Equal(2, filtered.Count);
+        Assert.Contains(filtered, h => h.HotelId == "alpha");
+        Assert.Contains(filtered, h => h.HotelId == "beta");
+        Assert.DoesNotContain(filtered, h => h.HotelId == "gamma");
+        Assert.DoesNotContain(filtered, h => h.HotelId == "delta");
+    }
+
+    [Fact]
     public async Task FilterSupportsLogicalOperatorsAndSkipAsync()
     {
         using var database = new LiteDatabase(new MemoryStream());
@@ -210,6 +419,30 @@ public sealed class LiteDbVectorStoreTests
         Assert.Contains(filtered, h => h.HotelId == "beta");
         Assert.Contains(filtered, h => h.HotelId == "gamma");
         Assert.Contains(filtered, h => h.HotelId == "delta");
+    }
+
+    [Fact]
+    public async Task BatchUpsertIsAtomicAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions { DisposeDatabase = false });
+
+        var collection = store.GetCollection<string, TestHotel>("hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        var storage = database.GetCollection(collection.Name);
+        storage.EnsureIndex(nameof(TestHotel.HotelName), unique: true);
+
+        var records = new[]
+        {
+            new TestHotel { HotelId = "alpha", HotelName = "Alpha", Rating = 5, City = "Seattle", Tags = new[] { "spa" }, DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f, 0f }) },
+            new TestHotel { HotelId = "beta", HotelName = "Alpha", Rating = 4, City = "Portland", Tags = new[] { "spa" }, DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 0f, 1f, 0f }) }
+        };
+
+        await Assert.ThrowsAsync<LiteException>(() => collection.UpsertAsync(records));
+
+        var persisted = storage.FindAll().ToList();
+        Assert.Empty(persisted);
     }
 
     [Fact]
@@ -246,6 +479,28 @@ public sealed class LiteDbVectorStoreTests
         Assert.Equal("city", fetched!["Category"]);
         var embedding = (ReadOnlyMemory<float>)fetched["Embedding"]!;
         Assert.Equal(new[] { 1f, 0f, 0f }, embedding.ToArray());
+    }
+
+    [Fact]
+    public async Task UpsertValidatesVectorDimensionsAsync()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        using var store = new LiteDbVectorStore(database, new LiteDbVectorStoreOptions { DisposeDatabase = false });
+
+        var collection = store.GetCollection<string, TestHotel>("hotels");
+        await collection.EnsureCollectionExistsAsync();
+
+        var record = new TestHotel
+        {
+            HotelId = "invalid",
+            HotelName = "Invalid",
+            Rating = 4,
+            City = "Seattle",
+            DescriptionEmbedding = new ReadOnlyMemory<float>(new[] { 1f, 0f })
+        };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => collection.UpsertAsync(record));
+        Assert.Contains("DescriptionEmbedding", ex.Message);
     }
 
     [Fact]
@@ -322,6 +577,56 @@ public sealed class LiteDbVectorStoreTests
     }
 
     [Fact]
+    public void DatabaseFactoryOverridesConnectionString()
+    {
+        LiteDatabase? created = null;
+        var options = new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            ConnectionString = "Filename=unused.db",
+            DatabaseFactory = () => created = new LiteDatabase(new MemoryStream())
+        };
+
+        using var store = new LiteDbVectorStore(options);
+
+        var database = GetDatabase(store);
+        Assert.Same(created, database);
+    }
+
+    [Fact]
+    public void ProvidedDatabaseOverridesConnectionString()
+    {
+        var stream = new MemoryStream();
+        var provided = new LiteDatabase(stream);
+
+        var options = new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            ConnectionString = "Filename=unused.db",
+            Database = provided
+        };
+
+        using var store = new LiteDbVectorStore(options);
+
+        var database = GetDatabase(store);
+        Assert.Same(provided, database);
+    }
+
+    [Fact]
+    public void ConnectionStringUsedWhenNoDatabaseProvided()
+    {
+        var options = new LiteDbVectorStoreOptions
+        {
+            DisposeDatabase = false,
+            ConnectionString = "Filename=my.db"
+        };
+
+        using var store = new LiteDbVectorStore(options);
+        var metadata = Assert.IsType<VectorStoreMetadata>(store.GetService(typeof(VectorStoreMetadata)));
+        Assert.Equal("Filename=my.db", metadata.VectorStoreName);
+    }
+
+    [Fact]
     public async Task ServiceCollectionRegistersLiteDbStoreAndCollectionsAsync()
     {
         var services = new ServiceCollection();
@@ -379,6 +684,12 @@ public sealed class LiteDbVectorStoreTests
         Assert.Contains("generated_hotels", collectionNames);
     }
 
+    private static LiteDatabase GetDatabase(LiteDbVectorStore store)
+    {
+        var field = typeof(LiteDbVectorStore).GetField("_database", BindingFlags.Instance | BindingFlags.NonPublic);
+        return Assert.IsType<LiteDatabase>(field!.GetValue(store));
+    }
+
     private sealed class TestHotel
     {
         [VectorStoreKey]
@@ -392,6 +703,9 @@ public sealed class LiteDbVectorStoreTests
 
         [VectorStoreData]
         public string? City { get; set; }
+
+        [VectorStoreData]
+        public string[]? Tags { get; set; }
 
         [VectorStoreVector(Dimensions: 3, DistanceFunction = DistanceFunction.CosineSimilarity)]
         public ReadOnlyMemory<float>? DescriptionEmbedding { get; set; }
@@ -422,6 +736,78 @@ public sealed class LiteDbVectorStoreTests
 
         [VectorStoreVector(Dimensions: 3, DistanceFunction = DistanceFunction.EuclideanDistance)]
         public ReadOnlyMemory<float>? Embedding { get; set; }
+    }
+
+    private sealed class CompositeGeneratedHotel
+    {
+        [VectorStoreKey]
+        public string? HotelId { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public string? Summary { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public string? Details { get; set; }
+    }
+
+    private sealed class MultiMetricHotel
+    {
+        [VectorStoreKey]
+        public string? HotelId { get; set; }
+
+        [VectorStoreVector(Dimensions: 3, DistanceFunction = DistanceFunction.DotProductSimilarity)]
+        public ReadOnlyMemory<float>? AmenitiesEmbedding { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public ReadOnlyMemory<float>? LocationEmbedding { get; set; }
+    }
+
+    private sealed class ZeroEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            var embeddings = new GeneratedEmbeddings<Embedding<float>>();
+            foreach (var _ in values)
+            {
+                embeddings.Add(new Embedding<float>(new float[] { 0f, 0f, 0f }));
+            }
+
+            return Task.FromResult(embeddings);
+        }
+
+        public Task<Embedding<float>> GenerateAsync(string value, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new Embedding<float>(new float[] { 0f, 0f, 0f }));
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class BlockingEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            var tcs = new TaskCompletionSource<GeneratedEmbeddings<Embedding<float>>>();
+            cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+            return tcs.Task;
+        }
+
+        public Task<Embedding<float>> GenerateAsync(string value, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            var tcs = new TaskCompletionSource<Embedding<float>>();
+            cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+            return tcs.Task;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => null;
+
+        public void Dispose()
+        {
+        }
     }
 
     private sealed class StringEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>


### PR DESCRIPTION
## Summary
- update the LiteDB mapper to support complex data values and keep vector search ordering aligned with the resolved metric
- extend the LiteDB filter translator with string/membership operators, better null handling, and captured constant evaluation
- refresh LiteDB documentation and samples, including a new advanced scenario and expanded unit test coverage

## Testing
- DOTNET_ROLL_FORWARD=LatestMajor dotnet test dotnet/test/VectorData/LiteDb.UnitTests/LiteDb.UnitTests.csproj
- DOTNET_ROLL_FORWARD=LatestMajor dotnet test dotnet/samples/GettingStartedWithVectorStores/GettingStartedWithVectorStores.csproj --filter Step5_LiteDb_Advanced


------
https://chatgpt.com/codex/tasks/task_e_68e5713f65b48326b6d82837216fc30c